### PR TITLE
重构生成文档的逻辑，修复了一些排版上的问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Checking and testing
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  type_check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests types-requests mypy
+      - name: Type checking
+        run: mypy main.py
+

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,8 +1,8 @@
 name: Koala hacker news
-on: 
+on:
   push:
     branches: main
-  schedule: 
+  schedule:
     - cron: '0 0 * * TUE'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,434 +2,491 @@
 
 b站up主[Koala聊开源](https://space.bilibili.com/489667127)的《hacker news 周报》[合集](https://space.bilibili.com/489667127/channel/collectiondetail?sid=249279)的内容总结 
 
-## [视频链接](https://www.bilibili.com/video/BV1GR4y1R7Yw)
+## [视频链接](https://www.bilibili.com/video/av261620356)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1GR4y1R7Yw?t=9)|sharing｜将电脑中的文件通过二维码分享给手机|https://github.com/parvardegr/sharing|
-|[00:31](https://www.bilibili.com/video/BV1GR4y1R7Yw?t=31)|Steampipe｜ 浏览云服务资产的交互式命令行工具|https://steampipe.io/|
-|[00:54](https://www.bilibili.com/video/BV1GR4y1R7Yw?t=54)|Horizon UI｜ 基于 Chakra UI 的管理后台模版|https://horizon-ui.com/|
-|[01:16](https://www.bilibili.com/video/BV1GR4y1R7Yw?t=76)|Postgres WASM｜ 开源 WASM 运行 PostgresSQL 方案|https://supabase.com/blog/postgres-wasm|
-|[01:50](https://www.bilibili.com/video/BV1GR4y1R7Yw?t=110)|v86｜ 通过 WebAssembly 运行 x86 兼容的虚拟机|https://github.com/copy/v86|
-|[02:06](https://www.bilibili.com/video/BV1GR4y1R7Yw?t=126)|libSQL｜ SQLite 下游版本|https://github.com/libsql/libsql & https://itnext.io/sqlite-qemu-all-over-again-aedad19c9a1c|
-|[02:38](https://www.bilibili.com/video/BV1GR4y1R7Yw?t=158)|TypeScript  10 years anniversary|https://devblogs.microsoft.com/typescript/ten-years-of-typescript/|
-| |Bam｜Wingsuit Flying by Michele Nobler| |
-## [视频链接](https://www.bilibili.com/video/BV1td4y1B7Y1)
+|[00:10](https://www.bilibili.com/video/av261620356?t=10)|Obsidian 发布 1.0|https://obsidian.md/1.0|
+|[00:28](https://www.bilibili.com/video/av261620356?t=28)|NocoDB｜ Airtable 开源替代品|https://github.com/nocodb/nocodb|
+|[00:47](https://www.bilibili.com/video/av261620356?t=47)|通过代码编辑视频|https://github.com/mifi|
+|[01:10](https://www.bilibili.com/video/av261620356?t=70)|Satori｜ 从 HTML 生成 SVG|https://github.com/vercel/satori|
+|[01:37](https://www.bilibili.com/video/av261620356?t=97)|aerc｜在命令行中编辑视频与收发邮件|https://aerc-mail.org/|
+|[01:54](https://www.bilibili.com/video/av261620356?t=114)|Fleet｜Jet Brains 新一代 IDE|https://www.jetbrains.com/fleet/|
+|[02:18](https://www.bilibili.com/video/av261620356?t=138)|Go 语言设计讨论|https://github.com/golang/go/discussions/56010|
+
+## [视频链接](https://www.bilibili.com/video/av346450481)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1td4y1B7Y1?t=9)|SigNoz｜开源的 APM 系统|https://github.com/SigNoz/signoz|
-|[00:35](https://www.bilibili.com/video/BV1td4y1B7Y1?t=35)|Wails｜使用 Go 和 Web 技术开发桌面端应用|https://wails.io/|
-|[00:58](https://www.bilibili.com/video/BV1td4y1B7Y1?t=58)|CloudFlare 开源 serverless 运行时 workerd|https://github.com/cloudflare/workerd|
-|[01:33](https://www.bilibili.com/video/BV1td4y1B7Y1?t=93)|Qwik｜builder.io 开源的前端框架|https://qwik.builder.io/|
-|[02:02](https://www.bilibili.com/video/BV1td4y1B7Y1?t=122)|pdfgrep｜命令行搜索工具|https://pdfgrep.org/|
-|[02:16](https://www.bilibili.com/video/BV1td4y1B7Y1?t=136)|Liqe｜轻量级搜索引擎|https://github.com/gajus/liqe|
-|[02:31](https://www.bilibili.com/video/BV1td4y1B7Y1?t=151)|Google 计划关停云游戏服务 Stadia|https://www.theverge.com/2022/9/29/23378713/google-stadia-shutting-down-game-streaming-january-2023|
-| |Bam｜Théâtre dombres chinois by Biba Dupont| |
-## [视频链接](https://www.bilibili.com/video/BV1Je4y1r7B4)
+|[00:09](https://www.bilibili.com/video/av346450481?t=9)|sharing｜将电脑中的文件通过二维码分享给手机|https://github.com/parvardegr/sharing|
+|[00:31](https://www.bilibili.com/video/av346450481?t=31)|Steampipe｜ 浏览云服务资产的交互式命令行工具|https://steampipe.io/|
+|[00:54](https://www.bilibili.com/video/av346450481?t=54)|Horizon UI｜ 基于 Chakra UI 的管理后台模版|https://horizon-ui.com/|
+|[01:16](https://www.bilibili.com/video/av346450481?t=76)|Postgres WASM｜ 开源 WASM 运行 PostgresSQL 方案|https://supabase.com/blog/postgres-wasm|
+|[01:50](https://www.bilibili.com/video/av346450481?t=110)|v86｜ 通过 WebAssembly 运行 x86 兼容的虚拟机|https://github.com/copy/v86|
+|[02:06](https://www.bilibili.com/video/av346450481?t=126)|libSQL｜ SQLite 下游版本|https://github.com/libsql/libsql<br>https://itnext.io/sqlite-qemu-all-over-again-aedad19c9a1c|
+|[02:38](https://www.bilibili.com/video/av346450481?t=158)|TypeScript  10 years anniversary|https://devblogs.microsoft.com/typescript/ten-years-of-typescript/|
+
+## [视频链接](https://www.bilibili.com/video/av388741659)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1Je4y1r7B4?t=9)|GitUI｜Git 终端 UI|https://github.com/extrawurst/gitui|
-|[00:35](https://www.bilibili.com/video/BV1Je4y1r7B4?t=35)|Dub｜开源短链接服务|https://dub.sh/|
-|[00:58](https://www.bilibili.com/video/BV1Je4y1r7B4?t=58)|WunderBase｜ serverless GraphQL 数据库|https://github.com/wundergraph/wunderbase|
-|[01:17](https://www.bilibili.com/video/BV1Je4y1r7B4?t=77)|Rocketry｜现代化的 Python 调度框架|https://github.com/Miksus/rocketry|
-|[01:33](https://www.bilibili.com/video/BV1Je4y1r7B4?t=93)|KREA｜AI 作画图库|https://www.krea.ai/|
-|[01:55](https://www.bilibili.com/video/BV1Je4y1r7B4?t=115)|Whisper｜ OpenAI 开源的语音识别系统|https://openai.com/blog/whisper|
-|[02:15](https://www.bilibili.com/video/BV1Je4y1r7B4?t=135)|fly.io 开源新项目 LiteFS|https://fly.io/blog/introducing-litefs|
-|[02:51](https://www.bilibili.com/video/BV1Je4y1r7B4?t=171)|Azure CTO Mark Russinovich 发推引发热议|https://twitter.com/markrussinovich/status/1571995117233504257|
-| |Bam｜Tornado by Liron Meyuhas; Tea Time by Ty Simon| |
-## [视频链接](https://www.bilibili.com/video/BV1QP411H7rM)
+|[00:09](https://www.bilibili.com/video/av388741659?t=9)|SigNoz｜开源的 APM 系统|https://github.com/SigNoz/signoz|
+|[00:35](https://www.bilibili.com/video/av388741659?t=35)|Wails｜使用 Go 和 Web 技术开发桌面端应用|https://wails.io/|
+|[00:58](https://www.bilibili.com/video/av388741659?t=58)|CloudFlare 开源 serverless 运行时 workerd|https://github.com/cloudflare/workerd|
+|[01:33](https://www.bilibili.com/video/av388741659?t=93)|Qwik｜builder.io 开源的前端框架|https://qwik.builder.io/|
+|[02:02](https://www.bilibili.com/video/av388741659?t=122)|pdfgrep｜命令行搜索工具|https://pdfgrep.org/|
+|[02:16](https://www.bilibili.com/video/av388741659?t=136)|Liqe｜轻量级搜索引擎|https://github.com/gajus/liqe|
+|[02:31](https://www.bilibili.com/video/av388741659?t=151)|Google 计划关停云游戏服务 Stadia|https://www.theverge.com/2022/9/29/23378713/google-stadia-shutting-down-game-streaming-january-2023|
+
+## [视频链接](https://www.bilibili.com/video/av558499331)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1QP411H7rM?t=9)|Figma 被收购引发在线设计工具新动向00:31 penpot｜开源设计工具因 Figma 变热|https://www.bloomberg.com/news/articles/2022-09-15/adobe-is-said-to-near-deal-to-buy-online-design-startup-figma|
-|[00:46](https://www.bilibili.com/video/BV1QP411H7rM?t=46)|Theatre.js｜开源在线动效编辑器|https://penpot.app/|
-|[01:08](https://www.bilibili.com/video/BV1QP411H7rM?t=68)|Markdoc｜交互式 Markdown|https://www.theatrejs.com/|
-|[01:25](https://www.bilibili.com/video/BV1QP411H7rM?t=85)|Meta 将 PyTorch 捐赠给 Linux 基金会|https://markdoc.dev/|
-|[01:37](https://www.bilibili.com/video/BV1QP411H7rM?t=97)|Meta 发布了网页内存泄漏检测工具 MemLab|https://www.linuxfoundation.org/blog/blog/welcoming-pytorch-to-the-linux-foundation|
-|[01:59](https://www.bilibili.com/video/BV1QP411H7rM?t=119)|SafeQL｜ 校验 SQL 的 ESLint 插件|https://engineering.fb.com/2022/09/12/open-source/memlab/|
-|[02:14](https://www.bilibili.com/video/BV1QP411H7rM?t=134)|Diffusion Bee｜在 M1 Mac 上运行 Stable Diffusion 的桌面端应用|https://safeql.dev/|
-| |Bam｜Cool Cats by Family Kush|https://github.com/divamgupta/diffusionbee-stable-diffusion-ui|
-## [视频链接](https://www.bilibili.com/video/BV1Pe4y187LV)
+|[00:09](https://www.bilibili.com/video/av558499331?t=9)|GitUI｜Git 终端 UI|https://github.com/extrawurst/gitui|
+|[00:35](https://www.bilibili.com/video/av558499331?t=35)|Dub｜开源短链接服务|https://dub.sh/|
+|[00:58](https://www.bilibili.com/video/av558499331?t=58)|WunderBase｜ serverless GraphQL 数据库|https://github.com/wundergraph/wunderbase|
+|[01:17](https://www.bilibili.com/video/av558499331?t=77)|Rocketry｜现代化的 Python 调度框架|https://github.com/Miksus/rocketry|
+|[01:33](https://www.bilibili.com/video/av558499331?t=93)|KREA｜AI 作画图库|https://www.krea.ai/|
+|[01:55](https://www.bilibili.com/video/av558499331?t=115)|Whisper｜ OpenAI 开源的语音识别系统|https://openai.com/blog/whisper|
+|[02:15](https://www.bilibili.com/video/av558499331?t=135)|fly.io 开源新项目 LiteFS|https://fly.io/blog/introducing-litefs|
+|[02:51](https://www.bilibili.com/video/av558499331?t=171)|Azure CTO Mark Russinovich 发推引发热议|https://twitter.com/markrussinovich/status/1571995117233504257|
+
+## [视频链接](https://www.bilibili.com/video/av303210611)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:11](https://www.bilibili.com/video/BV1Pe4y187LV?t=11)|Difftastic｜结构化 diff 工具|https://www.wilfred.me.uk/blog/2022/09/06/difftastic-the-fantastic-diff/|
-|[00:46](https://www.bilibili.com/video/BV1Pe4y187LV?t=46)|ruff｜百倍快的 Python linter|https://github.com/charliermarsh/ruff|
-|[01:12](https://www.bilibili.com/video/BV1Pe4y187LV?t=72)|DataEase｜数据可视化分析工具|https://github.com/dataease/dataease|
-|[01:36](https://www.bilibili.com/video/BV1Pe4y187LV?t=96)|MATHLIVE｜展示和编辑数学公式的 Web Component|https://cortexjs.io/mathlive|
-|[02:03](https://www.bilibili.com/video/BV1Pe4y187LV?t=123)|VSCheatsheet｜VS Code 快捷键合集|https://www.vscheatsheet.com/|
-|[02:24](https://www.bilibili.com/video/BV1Pe4y187LV?t=144)|Modern for Hacker News｜ 美化 Hacker News 界面的浏览器插件|https://www.modernhn.com/|
-|[02:37](https://www.bilibili.com/video/BV1Pe4y187LV?t=157)|signals｜PREACT 状态管理新方案|https://preactjs.com/blog/introducing-signals/|
-| |Bam｜Shake That Fever by Duffmusiq| |
-## [视频链接](https://www.bilibili.com/video/BV19e411g7qe)
+|[00:09](https://www.bilibili.com/video/av303210611?t=9)|Figma 被收购引发在线设计工具新动向|https://www.bloomberg.com/news/articles/2022-09-15/adobe-is-said-to-near-deal-to-buy-online-design-startup-figma|
+|[00:31](https://www.bilibili.com/video/av303210611?t=31)|penpot｜开源设计工具因 Figma 变热|https://penpot.app/|
+|[00:46](https://www.bilibili.com/video/av303210611?t=46)|Theatre.js｜开源在线动效编辑器|https://www.theatrejs.com/|
+|[01:08](https://www.bilibili.com/video/av303210611?t=68)|Markdoc｜交互式 Markdown|https://markdoc.dev/|
+|[01:25](https://www.bilibili.com/video/av303210611?t=85)|Meta 将 PyTorch 捐赠给 Linux 基金会|https://www.linuxfoundation.org/blog/blog/welcoming-pytorch-to-the-linux-foundation|
+|[01:37](https://www.bilibili.com/video/av303210611?t=97)|Meta 发布了网页内存泄漏检测工具 MemLab|https://engineering.fb.com/2022/09/12/open-source/memlab/|
+|[01:59](https://www.bilibili.com/video/av303210611?t=119)|SafeQL｜ 校验 SQL 的 ESLint 插件|https://safeql.dev/|
+|[02:14](https://www.bilibili.com/video/av303210611?t=134)|Diffusion Bee｜在 M1 Mac 上运行 Stable Diffusion 的桌面端应用|https://github.com/divamgupta/diffusionbee-stable-diffusion-ui|
+
+## [视频链接](https://www.bilibili.com/video/av560499744)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV19e411g7qe?t=9)|Devbox｜快速启动隔离开发环境| |
-|[00:38](https://www.bilibili.com/video/BV19e411g7qe?t=38)|绘图语言 D2| |
-|[00:52](https://www.bilibili.com/video/BV19e411g7qe?t=52)|YAO｜开发应用引擎| |
-|[01:20](https://www.bilibili.com/video/BV19e411g7qe?t=80)|JSON Crack｜JSON 可视化工具| |
-|[01:42](https://www.bilibili.com/video/BV19e411g7qe?t=102)|Motionity｜动效编辑器| |
-|[02:02](https://www.bilibili.com/video/BV19e411g7qe?t=122)|mvSQLite｜分布式 SQLite| |
-|[02:37](https://www.bilibili.com/video/BV19e411g7qe?t=157)|Heroku 即将停止免费额度| |
-|[03:01](https://www.bilibili.com/video/BV19e411g7qe?t=181)|GitHub 开发者关系副总裁回复移除 Trending| |
-## [视频链接](https://www.bilibili.com/video/BV1qa411G7kd)
+|[00:11](https://www.bilibili.com/video/av560499744?t=11)|Difftastic｜结构化 diff 工具|https://www.wilfred.me.uk/blog/2022/09/06/difftastic-the-fantastic-diff/|
+|[00:46](https://www.bilibili.com/video/av560499744?t=46)|ruff｜百倍快的 Python linter|https://github.com/charliermarsh/ruff|
+|[01:12](https://www.bilibili.com/video/av560499744?t=72)|DataEase｜数据可视化分析工具|https://github.com/dataease/dataease|
+|[01:36](https://www.bilibili.com/video/av560499744?t=96)|MATHLIVE｜展示和编辑数学公式的 Web Component|https://cortexjs.io/mathlive|
+|[02:03](https://www.bilibili.com/video/av560499744?t=123)|VSCheatsheet｜VS Code 快捷键合集|https://www.vscheatsheet.com/|
+|[02:24](https://www.bilibili.com/video/av560499744?t=144)|Modern for Hacker News｜ 美化 Hacker News 界面的浏览器插件|https://www.modernhn.com/|
+|[02:37](https://www.bilibili.com/video/av560499744?t=157)|signals｜PREACT 状态管理新方案|https://preactjs.com/blog/introducing-signals/|
+
+## [视频链接](https://www.bilibili.com/video/av260156898)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:38](https://www.bilibili.com/video/BV1qa411G7kd?t=38)|本期时间轴：00:09｜野心勃勃的数据库 SurrealDB|https://surrealdb.com/|
-|[00:59](https://www.bilibili.com/video/BV1qa411G7kd?t=59)|Stable Diffusion｜开源的 AI 图片生成模型|https://github.com/CompVis/stable-diffusion|
-|[01:24](https://www.bilibili.com/video/BV1qa411G7kd?t=84)|react-design-editor｜ Canva 的开源替代品|https://github.com/layerhub-io/react-design-editor|
-|[01:43](https://www.bilibili.com/video/BV1qa411G7kd?t=103)|Weylus｜将触屏设备变为触摸板|https://github.com/H-M-H/Weylus|
-|[02:04](https://www.bilibili.com/video/BV1qa411G7kd?t=124)|eInk-VNC｜将 VMC 输出到墨水屏|https://zmarshall.nl/static/eink-vnc.html|
-|[02:26](https://www.bilibili.com/video/BV1qa411G7kd?t=146)|SQLite 并发读取性能详解|https://fly.io/blog/sqlite-internals-wal|
-| |80 岁计算机科学家仍在优化开源代码|https://news.ycombinator.com/item?id=32534173|
-## [视频链接](https://www.bilibili.com/video/BV1bg411r7Fg)
+|[00:09](https://www.bilibili.com/video/av260156898?t=9)|Devbox｜快速启动隔离开发环境| |
+|[00:38](https://www.bilibili.com/video/av260156898?t=38)|绘图语言 D2| |
+|[00:52](https://www.bilibili.com/video/av260156898?t=52)|YAO｜开发应用引擎| |
+|[01:20](https://www.bilibili.com/video/av260156898?t=80)|JSON Crack｜JSON 可视化工具| |
+|[01:42](https://www.bilibili.com/video/av260156898?t=102)|Motionity｜动效编辑器| |
+|[02:02](https://www.bilibili.com/video/av260156898?t=122)|mvSQLite｜分布式 SQLite| |
+|[02:37](https://www.bilibili.com/video/av260156898?t=157)|Heroku 即将停止免费额度| |
+|[03:01](https://www.bilibili.com/video/av260156898?t=181)|GitHub 开发者关系副总裁回复移除 Trending| |
+
+## [视频链接](https://www.bilibili.com/video/av217441979)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:10](https://www.bilibili.com/video/BV1bg411r7Fg?t=10)|Numpad ｜一个新式文本编辑器|https://numpad.io/|
-|[00:34](https://www.bilibili.com/video/BV1bg411r7Fg?t=34)|Erg｜与 Python 兼容的静态类型语言|https://github.com/erg-lang/erg|
-|[00:57](https://www.bilibili.com/video/BV1bg411r7Fg?t=57)|分布式文件系统 JuiceFS|https://github.com/juicedata/juicefs|
-|[01:22](https://www.bilibili.com/video/BV1bg411r7Fg?t=82)|JiraCLI｜ 对 Jira 的命令行客户端|https://github.com/ankitpokhrel/jira-cli|
-|[01:33](https://www.bilibili.com/video/BV1bg411r7Fg?t=93)|Crunchy Data｜在浏览器中运行 Postgres|https://www.crunchydata.com/blog/learn-postgres-at-the-playground|
-|[01:53](https://www.bilibili.com/video/BV1bg411r7Fg?t=113)|JSON5 作者的一篇博客|https://aseemk.substack.com/p/ignore-the-f-ing-haters-json5|
-## [视频链接](https://www.bilibili.com/video/BV1UB4y1t7cW)
+|[00:09](https://www.bilibili.com/video/av217441979?t=9)|｜野心勃勃的数据库 SurrealDB|https://surrealdb.com/|
+|[00:38](https://www.bilibili.com/video/av217441979?t=38)|Stable Diffusion｜开源的 AI 图片生成模型|https://github.com/CompVis/stable-diffusion|
+|[00:59](https://www.bilibili.com/video/av217441979?t=59)|react-design-editor｜ Canva 的开源替代品|https://github.com/layerhub-io/react-design-editor|
+|[01:24](https://www.bilibili.com/video/av217441979?t=84)|Weylus｜将触屏设备变为触摸板|https://github.com/H-M-H/Weylus|
+|[01:43](https://www.bilibili.com/video/av217441979?t=103)|eInk-VNC｜将 VMC 输出到墨水屏|https://zmarshall.nl/static/eink-vnc.html|
+|[02:04](https://www.bilibili.com/video/av217441979?t=124)|SQLite 并发读取性能详解|https://fly.io/blog/sqlite-internals-wal|
+|[02:26](https://www.bilibili.com/video/av217441979?t=146)|80 岁计算机科学家仍在优化开源代码|https://news.ycombinator.com/item?id=32534173|
+
+## [视频链接](https://www.bilibili.com/video/av514731265)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1UB4y1t7cW?t=9)|远程开发方案 Coder|https://coder.com/|
-|[00:34](https://www.bilibili.com/video/BV1UB4y1t7cW?t=34)|高性能 virtual DOM|https://millionjs.org/|
-|[01:04](https://www.bilibili.com/video/BV1UB4y1t7cW?t=64)|Astro 发布了 1.0 版本|https://astro.build/blog/astro-1/|
-|[01:28](https://www.bilibili.com/video/BV1UB4y1t7cW?t=88)|Multy｜ 基于 Terraform 的跨云部署框架|https://github.com/multycloud/multy|
-|[01:54](https://www.bilibili.com/video/BV1UB4y1t7cW?t=114)|Rancher 创始团队运营新开源产品 Acorn|https://acorn.io/|
-|[02:21](https://www.bilibili.com/video/BV1UB4y1t7cW?t=141)|一篇介绍 Redis 技术细节的文章|https://architecturenotes.co/redis/|
-## [视频链接](https://www.bilibili.com/video/BV1VN4y1j7Pd)
+|[00:10](https://www.bilibili.com/video/av514731265?t=10)|Numpad ｜一个新式文本编辑器|https://numpad.io/|
+|[00:34](https://www.bilibili.com/video/av514731265?t=34)|Erg｜与 Python 兼容的静态类型语言|https://github.com/erg-lang/erg|
+|[00:57](https://www.bilibili.com/video/av514731265?t=57)|分布式文件系统 JuiceFS|https://github.com/juicedata/juicefs|
+|[01:22](https://www.bilibili.com/video/av514731265?t=82)|JiraCLI｜ 对 Jira 的命令行客户端|https://github.com/ankitpokhrel/jira-cli|
+|[01:33](https://www.bilibili.com/video/av514731265?t=93)|Crunchy Data｜在浏览器中运行 Postgres|https://www.crunchydata.com/blog/learn-postgres-at-the-playground|
+|[01:53](https://www.bilibili.com/video/av514731265?t=113)|JSON5 作者的一篇博客|https://aseemk.substack.com/p/ignore-the-f-ing-haters-json5|
+
+## [视频链接](https://www.bilibili.com/video/av601882126)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:08](https://www.bilibili.com/video/BV1VN4y1j7Pd?t=8)|开源知识库软件能否替代 Notion|https://github.com/toeverything/AFFiNE|
-|[00:35](https://www.bilibili.com/video/BV1VN4y1j7Pd?t=35)|Copilot 开源替代品|https://github.com/moyix/fauxpilot|
-|[00:52](https://www.bilibili.com/video/BV1VN4y1j7Pd?t=52)|逆向工程工具箱|https://github.com/WerWolv/ImHex|
-|[01:08](https://www.bilibili.com/video/BV1VN4y1j7Pd?t=68)|Emery｜效率工具|https://emery.to/|
-|[01:24](https://www.bilibili.com/video/BV1VN4y1j7Pd?t=84)|一篇介绍 eBPF 技术的文章|https://www.groundcover.com/blog/what-is-ebpf|
-|[01:50](https://www.bilibili.com/video/BV1VN4y1j7Pd?t=110)|用 DALL·E 2 生成 logo 图片的分享文章|https://jacobmartins.com/posts/how-i-used-dalle2-to-generate-the-logo-for-octosql/|
-## [视频链接](https://www.bilibili.com/video/BV1hV4y177P9)
+|[00:09](https://www.bilibili.com/video/av601882126?t=9)|远程开发方案 Coder|https://coder.com/|
+|[00:34](https://www.bilibili.com/video/av601882126?t=34)|高性能 virtual DOM|https://millionjs.org/|
+|[01:04](https://www.bilibili.com/video/av601882126?t=64)|Astro 发布了 1.0 版本|https://astro.build/blog/astro-1/|
+|[01:28](https://www.bilibili.com/video/av601882126?t=88)|Multy｜ 基于 Terraform 的跨云部署框架|https://github.com/multycloud/multy|
+|[01:54](https://www.bilibili.com/video/av601882126?t=114)|Rancher 创始团队运营新开源产品 Acorn|https://acorn.io/|
+|[02:21](https://www.bilibili.com/video/av601882126?t=141)|一篇介绍 Redis 技术细节的文章|https://architecturenotes.co/redis/|
+
+## [视频链接](https://www.bilibili.com/video/av899145721)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:11](https://www.bilibili.com/video/BV1hV4y177P9?t=11)|Google 发布新编程语言 Carbon|https://github.com/carbon-language/carbon-lang|
-|[00:58](https://www.bilibili.com/video/BV1hV4y177P9?t=58)|榫卯｜ Sunmao ｜低代码工具开发框架|https://github.com/smartxworks/sunmao-ui|
-|[01:40](https://www.bilibili.com/video/BV1hV4y177P9?t=100)|Comcast｜模拟弱网环境的工具|https://github.com/tylertreat/comcast|
-|[02:36](https://www.bilibili.com/video/BV1hV4y177P9?t=156)|Tweakpane｜ 一个调节参数的 JS 库|https://cocopon.github.io/tweakpane/|
-|[02:58](https://www.bilibili.com/video/BV1hV4y177P9?t=178)|AI 系统 DALL·E 开放 Beta 测试|https://openai.com/blog/dall-e-now-available-in-beta|
-|[03:21](https://www.bilibili.com/video/BV1hV4y177P9?t=201)|一篇关于 Scratch 潜能的文章|https://www.bryanbraun.com/2022/07/16/scratch-is-a-big-deal|
-## [视频链接](https://www.bilibili.com/video/BV16N4y1T7Hu)
+|[00:08](https://www.bilibili.com/video/av899145721?t=8)|开源知识库软件能否替代 Notion|https://github.com/toeverything/AFFiNE|
+|[00:35](https://www.bilibili.com/video/av899145721?t=35)|Copilot 开源替代品|https://github.com/moyix/fauxpilot|
+|[00:52](https://www.bilibili.com/video/av899145721?t=52)|逆向工程工具箱|https://github.com/WerWolv/ImHex|
+|[01:08](https://www.bilibili.com/video/av899145721?t=68)|Emery｜效率工具|https://emery.to/|
+|[01:24](https://www.bilibili.com/video/av899145721?t=84)|一篇介绍 eBPF 技术的文章|https://www.groundcover.com/blog/what-is-ebpf|
+|[01:50](https://www.bilibili.com/video/av899145721?t=110)|用 DALL·E 2 生成 logo 图片的分享文章|https://jacobmartins.com/posts/how-i-used-dalle2-to-generate-the-logo-for-octosql/|
+
+## [视频链接](https://www.bilibili.com/video/av471440344)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:12](https://www.bilibili.com/video/BV16N4y1T7Hu?t=12)|Vite 发布3.0版本|https://vitejs.dev/blog/announcing-vite3.html|
-|[00:30](https://www.bilibili.com/video/BV16N4y1T7Hu?t=30)|VictoriaMetrics｜Prometheus 的开源替代品|https://victoriametrics.com/products/open-source/|
-|[01:02](https://www.bilibili.com/video/BV16N4y1T7Hu?t=62)|对 Bun 和 Node.js 对比实测|https://techsparx.com/nodejs/bun/1st-trial.html|
-|[01:49](https://www.bilibili.com/video/BV16N4y1T7Hu?t=109)|Cleanupphotos｜修图工具|https://cleanupphotos.com/|
-|[02:14](https://www.bilibili.com/video/BV16N4y1T7Hu?t=134)|Vim 在线交互式学习平台|https://www.vimified.com/|
-|[02:36](https://www.bilibili.com/video/BV16N4y1T7Hu?t=156)|推荐《PostgreSQL 14 Internals》一书|https://postgrespro.com/community/books/internals|
-## [视频链接](https://www.bilibili.com/video/BV1Wg411f7VV)
+
+## [视频链接](https://www.bilibili.com/video/av856201719)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1Wg411f7VV?t=9)|Bun｜高性能 JS 运行时|https://bun.sh/|
-|[00:40](https://www.bilibili.com/video/BV1Wg411f7VV?t=40)|TAURI｜Electron 轻量级替代品|https://tauri.app/|
-|[01:02](https://www.bilibili.com/video/BV1Wg411f7VV?t=62)|Felt｜在线地图编辑网站|https://felt.com/|
-|[01:19](https://www.bilibili.com/video/BV1Wg411f7VV?t=79)|PocketBase｜ 开源实时后端方案|https://pocketbase.io/|
-|[01:44](https://www.bilibili.com/video/BV1Wg411f7VV?t=104)|fuite｜自动探测 Web 应用内存泄漏|https://github.com/nolanlawson/fuite|
-|[02:05](https://www.bilibili.com/video/BV1Wg411f7VV?t=125)|一篇关于 rsync 工作原理的文章|https://michael.stapelberg.ch/posts/2022-07-02-rsync-how-does-it-work|
-## [视频链接](https://www.bilibili.com/video/BV1Xr4y1M7T7)
+|[00:11](https://www.bilibili.com/video/av856201719?t=11)|Google 发布新编程语言 Carbon|https://github.com/carbon-language/carbon-lang|
+|[00:58](https://www.bilibili.com/video/av856201719?t=58)|榫卯｜ Sunmao ｜低代码工具开发框架|https://github.com/smartxworks/sunmao-ui|
+|[01:40](https://www.bilibili.com/video/av856201719?t=100)|Comcast｜模拟弱网环境的工具|https://github.com/tylertreat/comcast|
+|[02:36](https://www.bilibili.com/video/av856201719?t=156)|Tweakpane｜ 一个调节参数的 JS 库|https://cocopon.github.io/tweakpane/|
+|[02:58](https://www.bilibili.com/video/av856201719?t=178)|AI 系统 DALL·E 开放 Beta 测试|https://openai.com/blog/dall-e-now-available-in-beta|
+|[03:21](https://www.bilibili.com/video/av856201719?t=201)|一篇关于 Scratch 潜能的文章|https://www.bryanbraun.com/2022/07/16/scratch-is-a-big-deal|
+
+## [视频链接](https://www.bilibili.com/video/av898526676)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:10](https://www.bilibili.com/video/BV1Xr4y1M7T7?t=10)|Pyroscope｜性能持续分析工具|https://pyroscope.io/|
-|[00:35](https://www.bilibili.com/video/BV1Xr4y1M7T7?t=35)|daisyUI｜前端组件库|https://daisyui.com/|
-|[00:55](https://www.bilibili.com/video/BV1Xr4y1M7T7?t=55)|《数据库必须知道的那些事》|https://architecturenotes.co/things-you-should-know-about-databases|
-|[01:21](https://www.bilibili.com/video/BV1Xr4y1M7T7?t=81)|《浏览器是如何工作的》|https://web.dev/howbrowserswork/|
-|[01:49](https://www.bilibili.com/video/BV1Xr4y1M7T7?t=109)|Spark 与 K8s 集成新动向|https://www.cncf.io/blog/2022/06/30/why-spark-chooses-volcano-as-built-in-batch-scheduler-on-kubernetes/|
-|[02:15](https://www.bilibili.com/video/BV1Xr4y1M7T7?t=135)|Raindrop｜书签管理小工具|https://raindrop.io/|
-## [视频链接](https://www.bilibili.com/video/BV1B3411u7ZG)
+|[00:12](https://www.bilibili.com/video/av898526676?t=12)|Vite 发布3.0版本|https://vitejs.dev/blog/announcing-vite3.html|
+|[00:30](https://www.bilibili.com/video/av898526676?t=30)|VictoriaMetrics｜Prometheus 的开源替代品|https://victoriametrics.com/products/open-source/|
+|[01:02](https://www.bilibili.com/video/av898526676?t=62)|对 Bun 和 Node.js 对比实测|https://techsparx.com/nodejs/bun/1st-trial.html|
+|[01:49](https://www.bilibili.com/video/av898526676?t=109)|Cleanupphotos｜修图工具|https://cleanupphotos.com/|
+|[02:14](https://www.bilibili.com/video/av898526676?t=134)|Vim 在线交互式学习平台|https://www.vimified.com/|
+|[02:36](https://www.bilibili.com/video/av898526676?t=156)|推荐《PostgreSQL 14 Internals》一书|https://postgrespro.com/community/books/internals|
+
+## [视频链接](https://www.bilibili.com/video/av513340184)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1B3411u7ZG?t=9)|Github AI 代码助手 Copilot 正式发布|https://github.blog/2022-06-21-github-copilot-is-generally-available-to-all-developers/|
-|[00:46](https://www.bilibili.com/video/BV1B3411u7ZG?t=46)|Markone｜绘制时间轴的工具|https://markwhen.com/|
-|[01:01](https://www.bilibili.com/video/BV1B3411u7ZG?t=61)|Viddy｜现代的 watch 替代品|https://github.com/sachaos/viddy|
-|[01:21](https://www.bilibili.com/video/BV1B3411u7ZG?t=81)|Elastic UI｜Elastic 开源的前端 UI 组件库|https://elastic.github.io/eui/#/|
-|[01:49](https://www.bilibili.com/video/BV1B3411u7ZG?t=109)|Avo｜构建在 Ruby on Rails 方案之上的应用开发框架|https://avohq.io/|
-|[02:23](https://www.bilibili.com/video/BV1B3411u7ZG?t=143)|Unclutter｜整理网页的浏览器插件|https://unclutter.lindylearn.io/|
-|[02:43](https://www.bilibili.com/video/BV1B3411u7ZG?t=163)|SQLite 发布 SQLite4 设计|https://sqlite.org/src4/doc/trunk/www/design.wiki|
-|[03:04](https://www.bilibili.com/video/BV1B3411u7ZG?t=184)|Deno 完成 A 轮融资|https://deno.com/blog/series-a|
-## [视频链接](https://www.bilibili.com/video/BV1sY411T7QL)
+|[00:09](https://www.bilibili.com/video/av513340184?t=9)|Bun｜高性能 JS 运行时|https://bun.sh/|
+|[00:40](https://www.bilibili.com/video/av513340184?t=40)|TAURI｜Electron 轻量级替代品|https://tauri.app/|
+|[01:02](https://www.bilibili.com/video/av513340184?t=62)|Felt｜在线地图编辑网站|https://felt.com/|
+|[01:19](https://www.bilibili.com/video/av513340184?t=79)|PocketBase｜ 开源实时后端方案|https://pocketbase.io/|
+|[01:44](https://www.bilibili.com/video/av513340184?t=104)|fuite｜自动探测 Web 应用内存泄漏|https://github.com/nolanlawson/fuite|
+|[02:05](https://www.bilibili.com/video/av513340184?t=125)|一篇关于 rsync 工作原理的文章|https://michael.stapelberg.ch/posts/2022-07-02-rsync-how-does-it-work|
+
+## [视频链接](https://www.bilibili.com/video/av770511400)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1sY411T7QL?t=9)|FRESH｜Deno 原生 SSR Web 框架| |
-|[00:34](https://www.bilibili.com/video/BV1sY411T7QL?t=34)|Vitest｜基于 vite 的单元测试框架| |
-|[00:55](https://www.bilibili.com/video/BV1sY411T7QL?t=55)|Rulex｜新的正则表达式语言| |
-|[01:14](https://www.bilibili.com/video/BV1sY411T7QL?t=74)|Recut｜视频剪辑工具| |
-|[01:31](https://www.bilibili.com/video/BV1sY411T7QL?t=91)|moon｜构建工具| |
-|[01:46](https://www.bilibili.com/video/BV1sY411T7QL?t=106)|一个寻找项目灵感的网站| |
-|[02:01](https://www.bilibili.com/video/BV1sY411T7QL?t=121)|程序员社交新尝试| |
-## [视频链接](https://www.bilibili.com/video/BV1rS4y1i72U)
+|[00:10](https://www.bilibili.com/video/av770511400?t=10)|Pyroscope｜性能持续分析工具|https://pyroscope.io/|
+|[00:35](https://www.bilibili.com/video/av770511400?t=35)|daisyUI｜前端组件库|https://daisyui.com/|
+|[00:55](https://www.bilibili.com/video/av770511400?t=55)|《数据库必须知道的那些事》|https://architecturenotes.co/things-you-should-know-about-databases|
+|[01:21](https://www.bilibili.com/video/av770511400?t=81)|《浏览器是如何工作的》|https://web.dev/howbrowserswork/|
+|[01:49](https://www.bilibili.com/video/av770511400?t=109)|Spark 与 K8s 集成新动向|https://www.cncf.io/blog/2022/06/30/why-spark-chooses-volcano-as-built-in-batch-scheduler-on-kubernetes/|
+|[02:15](https://www.bilibili.com/video/av770511400?t=135)|Raindrop｜书签管理小工具|https://raindrop.io/|
+
+## [视频链接](https://www.bilibili.com/video/av427756499)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1rS4y1i72U?t=9)|Knight Lab｜用代码更好地讲故事|https://knightlab.northwestern.edu/projects/|
-|[00:30](https://www.bilibili.com/video/BV1rS4y1i72U?t=30)|plasmo｜浏览器插件开发平台|https://www.plasmo.com/|
-|[00:49](https://www.bilibili.com/video/BV1rS4y1i72U?t=49)|Shotcut｜开源免费跨平台视频编辑器|https://shotcut.org/|
-|[01:06](https://www.bilibili.com/video/BV1rS4y1i72U?t=66)|DEEPKIT｜Typescript 高性能框架|https://deepkit.io/|
-|[01:24](https://www.bilibili.com/video/BV1rS4y1i72U?t=84)|opensourcealternative.to｜查找开源替代品的网站|https://www.opensourcealternative.to/|
-|[01:42](https://www.bilibili.com/video/BV1rS4y1i72U?t=102)|untools｜一组帮助思考的工具和方法论|https://untools.co/|
-## [视频链接](https://www.bilibili.com/video/BV1L34y1L7zK)
+|[01:01](https://www.bilibili.com/video/av427756499?t=61)|Viddy｜现代的 watch 替代品|https://github.blog/2022-06-21-github-copilot-is-generally-available-to-all-developers/|
+|[01:21](https://www.bilibili.com/video/av427756499?t=81)|Elastic UI｜Elastic 开源的前端 UI 组件库|https://markwhen.com/|
+|[01:49](https://www.bilibili.com/video/av427756499?t=109)|Avo｜构建在 Ruby on Rails 方案之上的应用开发框架|https://github.com/sachaos/viddy|
+|[02:23](https://www.bilibili.com/video/av427756499?t=143)|Unclutter｜整理网页的浏览器插件|https://elastic.github.io/eui/#/|
+|[02:43](https://www.bilibili.com/video/av427756499?t=163)|SQLite 发布 SQLite4 设计|https://avohq.io/|
+|[03:04](https://www.bilibili.com/video/av427756499?t=184)|Deno 完成 A 轮融资|https://unclutter.lindylearn.io/|
+| | |https://sqlite.org/src4/doc/trunk/www/design.wiki|
+| | |https://deno.com/blog/series-a|
+
+## [视频链接](https://www.bilibili.com/video/av257594368)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1L34y1L7zK?t=9)|Dragonfly｜一个25倍快的 Redis 竞品|https://github.com/dragonflydb/dragonfly|
-|[00:50](https://www.bilibili.com/video/BV1L34y1L7zK?t=50)|PlantUML｜快速编写 UML 图|https://plantuml.com/|
-|[01:12](https://www.bilibili.com/video/BV1L34y1L7zK?t=72)|Neon｜开源 serverless Postgres 方案|https://neon.tech/|
-|[01:39](https://www.bilibili.com/video/BV1L34y1L7zK?t=99)|ROAPI｜数据聚合 API|https://github.com/roapi/roapi|
-|[02:18](https://www.bilibili.com/video/BV1L34y1L7zK?t=138)|Tetra｜一个全栈框架|https://www.tetraframework.com/|
-|[02:49](https://www.bilibili.com/video/BV1L34y1L7zK?t=169)|fd｜终端工具 Find 的替代品|https://github.com/sharkdp/fd|
-|[03:05](https://www.bilibili.com/video/BV1L34y1L7zK?t=185)|svelvet｜交互式关系图构建工具|https://svelvet.io/docs/basic-usage/|
-|[03:22](https://www.bilibili.com/video/BV1L34y1L7zK?t=202)|ffmpeg buddy｜FFmpeg 命令生成工具|https://evanhahn.github.io/ffmpeg-buddy/|
-## [视频链接](https://www.bilibili.com/video/BV1pY4y1z7Vx)
+
+## [视频链接](https://www.bilibili.com/video/av727379202)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1pY4y1z7Vx?t=9)|PikaScript ｜ 超轻量级 Python 引擎|https://github.com/pikasTech/pikascript|
-|[00:26](https://www.bilibili.com/video/BV1pY4y1z7Vx?t=26)|bionic-reading 的快速阅读英文插件|https://github.com/ansh/bionic-reading|
-|[00:43](https://www.bilibili.com/video/BV1pY4y1z7Vx?t=43)|IndigoStack｜MacOS 平台上的本地开发环境|https://indigostack.app/|
-|[01:03](https://www.bilibili.com/video/BV1pY4y1z7Vx?t=63)|TypeScript 发布4.7版本|https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/|
-|[01:20](https://www.bilibili.com/video/BV1pY4y1z7Vx?t=80)|AnimatiSS｜一组 CSS 动画合集|https://xsgames.co/animatiss|
-|[01:32](https://www.bilibili.com/video/BV1pY4y1z7Vx?t=92)|Arctype｜ SQL 数据库客户端|https://arctype.com/|
-|[01:47](https://www.bilibili.com/video/BV1pY4y1z7Vx?t=107)|一个有趣的3D 植物生成工具|https://plant.jim-fx.com/|
-## [视频链接](https://www.bilibili.com/video/BV13a411E7AQ)
+|[00:09](https://www.bilibili.com/video/av727379202?t=9)|Knight Lab｜用代码更好地讲故事|https://knightlab.northwestern.edu/projects/|
+|[00:30](https://www.bilibili.com/video/av727379202?t=30)|plasmo｜浏览器插件开发平台|https://www.plasmo.com/|
+|[00:49](https://www.bilibili.com/video/av727379202?t=49)|Shotcut｜开源免费跨平台视频编辑器|https://shotcut.org/|
+|[01:06](https://www.bilibili.com/video/av727379202?t=66)|DEEPKIT｜Typescript 高性能框架|https://deepkit.io/|
+|[01:24](https://www.bilibili.com/video/av727379202?t=84)|opensourcealternative.to｜查找开源替代品的网站|https://www.opensourcealternative.to/|
+|[01:42](https://www.bilibili.com/video/av727379202?t=102)|untools｜一组帮助思考的工具和方法论|https://untools.co/|
+
+## [视频链接](https://www.bilibili.com/video/av812156413)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV13a411E7AQ?t=9)|Bud ｜ GO 的全栈 web 框架|https://github.com/livebud/bud|
-|[00:38](https://www.bilibili.com/video/BV13a411E7AQ?t=38)|Aspect ｜ 可视化开发 React 组件|https://aspect.app/|
-|[00:57](https://www.bilibili.com/video/BV13a411E7AQ?t=57)|在 SQLite 中使用 JSON 和 virtual columns|https://antonz.org/json-virtual-columns|
-|[01:17](https://www.bilibili.com/video/BV13a411E7AQ?t=77)|Sliderland｜一个极简风格的 JS 实验园地|https://sliderland.blinry.org/|
-|[01:39](https://www.bilibili.com/video/BV13a411E7AQ?t=99)|LiveTerm｜开发终端风格网站|https://liveterm.vercel.app/|
-|[01:56](https://www.bilibili.com/video/BV13a411E7AQ?t=116)|Datadog 介绍第三代事件存储库 Husky|https://www.datadoghq.com/blog/engineering/introducing-husky|
-|[02:16](https://www.bilibili.com/video/BV13a411E7AQ?t=136)|Quastor｜一个汇集大厂架构分析的专栏频道|https://quastor.substack.com/|
-| |🍒本期 bgm｜Pickin’ the Creep| |
-## [视频链接](https://www.bilibili.com/video/BV1kT4y1B7Nh)
+|[00:09](https://www.bilibili.com/video/av812156413?t=9)|Dragonfly｜一个25倍快的 Redis 竞品|https://github.com/dragonflydb/dragonfly|
+|[00:50](https://www.bilibili.com/video/av812156413?t=50)|PlantUML｜快速编写 UML 图|https://plantuml.com/|
+|[01:12](https://www.bilibili.com/video/av812156413?t=72)|Neon｜开源 serverless Postgres 方案|https://neon.tech/|
+|[01:39](https://www.bilibili.com/video/av812156413?t=99)|ROAPI｜数据聚合 API|https://github.com/roapi/roapi|
+|[02:18](https://www.bilibili.com/video/av812156413?t=138)|Tetra｜一个全栈框架|https://www.tetraframework.com/|
+|[02:49](https://www.bilibili.com/video/av812156413?t=169)|fd｜终端工具 Find 的替代品|https://github.com/sharkdp/fd|
+|[03:05](https://www.bilibili.com/video/av812156413?t=185)|svelvet｜交互式关系图构建工具|https://svelvet.io/docs/basic-usage/|
+|[03:22](https://www.bilibili.com/video/av812156413?t=202)|ffmpeg buddy｜FFmpeg 命令生成工具|https://evanhahn.github.io/ffmpeg-buddy/|
+
+## [视频链接](https://www.bilibili.com/video/av639600552)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:10](https://www.bilibili.com/video/BV1kT4y1B7Nh?t=10)|BoltDB 作者的博客｜如何在 fly.io 中使用 SQLite|https://fly.io/blog/all-in-on-sqlite-litestream|
-|[00:40](https://www.bilibili.com/video/BV1kT4y1B7Nh?t=40)|Litestream｜ Sqlite 实时复制工具|https://github.com/benbjohnson/litestream|
-|[00:49](https://www.bilibili.com/video/BV1kT4y1B7Nh?t=49)|Cloudflare 发布 D1|https://blog.cloudflare.com/introducing-d1/|
-|[01:21](https://www.bilibili.com/video/BV1kT4y1B7Nh?t=81)|rqlite｜ 与 D1 相似的开源分布式数据库|https://github.com/rqlite/rqlite|
-|[01:33](https://www.bilibili.com/video/BV1kT4y1B7Nh?t=93)|CaskDB｜一个 kv 存储引擎的教学工具|https://github.com/avinassh/py-caskdb|
-|[01:54](https://www.bilibili.com/video/BV1kT4y1B7Nh?t=114)|CubeDesk｜魔方提速工具|https://www.cubedesk.io/home|
-|[02:16](https://www.bilibili.com/video/BV1kT4y1B7Nh?t=136)|DFlex ｜一个适配所有 JS 框架的可拖拽的工具库|https://www.dflex.dev/|
-|[02:30](https://www.bilibili.com/video/BV1kT4y1B7Nh?t=150)|一篇 JS 性能分析指南的文章|https://blog.atomrc.dev/p/js-performance-profiling/|
-| |🍓本期 bgm｜ The Bahamas| |
-## [视频链接](https://www.bilibili.com/video/BV1PB4y1278B)
+|[00:09](https://www.bilibili.com/video/av639600552?t=9)|PikaScript ｜ 超轻量级 Python 引擎|https://github.com/pikasTech/pikascript|
+|[00:26](https://www.bilibili.com/video/av639600552?t=26)|bionic-reading 的快速阅读英文插件|https://github.com/ansh/bionic-reading|
+|[00:43](https://www.bilibili.com/video/av639600552?t=43)|IndigoStack｜MacOS 平台上的本地开发环境|https://indigostack.app/|
+|[01:03](https://www.bilibili.com/video/av639600552?t=63)|TypeScript 发布4.7版本|https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/|
+|[01:20](https://www.bilibili.com/video/av639600552?t=80)|AnimatiSS｜一组 CSS 动画合集|https://xsgames.co/animatiss|
+|[01:32](https://www.bilibili.com/video/av639600552?t=92)|Arctype｜ SQL 数据库客户端|https://arctype.com/|
+|[01:47](https://www.bilibili.com/video/av639600552?t=107)|一个有趣的3D 植物生成工具|https://plant.jim-fx.com/|
+
+## [视频链接](https://www.bilibili.com/video/av214334199)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1PB4y1278B?t=9)|Anaconda 发布 PyScript｜浏览器中运行 Python|https://www.anaconda.com/blog/pyscript-python-in-the-browser|
-|[00:37](https://www.bilibili.com/video/BV1PB4y1278B?t=37)|JSONHERO｜JSON 可视化工具|https://jsonhero.io/j/JZw4Wx9Mgj6r/tree|
-|[00:52](https://www.bilibili.com/video/BV1PB4y1278B?t=52)|Spacedrive｜本地和云端同在的文件管理器|https://www.spacedrive.app/|
-|[01:10](https://www.bilibili.com/video/BV1PB4y1278B?t=70)|Bash-Oneliner｜一个事例仓库|https://github.com/onceupon/Bash-Oneliner|
-|[01:23](https://www.bilibili.com/video/BV1PB4y1278B?t=83)|Fig｜ 与 Warp 类似的终端|https://fig.io/|
-|[01:39](https://www.bilibili.com/video/BV1PB4y1278B?t=99)|nosleep｜避免电脑休眠的网页|https://nosleep.page/|
-|[02:00](https://www.bilibili.com/video/BV1PB4y1278B?t=120)|一篇关于 Golang 的文章|https://fasterthanli.me/articles/lies-we-tell-ourselves-to-keep-using-golang|
-|[02:21](https://www.bilibili.com/video/BV1PB4y1278B?t=141)|移植到 web 上的《塞尔达传说》|https://hoten.cc/blog/porting-zelda-classic-to-the-web|
-| |🍓本期 bgm｜I don't get the lesson| |
-## [视频链接](https://www.bilibili.com/video/BV1fu41167ME)
+|[00:09](https://www.bilibili.com/video/av214334199?t=9)|Bud ｜ GO 的全栈 web 框架|https://github.com/livebud/bud|
+|[00:38](https://www.bilibili.com/video/av214334199?t=38)|Aspect ｜ 可视化开发 React 组件|https://aspect.app/|
+|[00:57](https://www.bilibili.com/video/av214334199?t=57)|在 SQLite 中使用 JSON 和 virtual columns|https://antonz.org/json-virtual-columns|
+|[01:17](https://www.bilibili.com/video/av214334199?t=77)|Sliderland｜一个极简风格的 JS 实验园地|https://sliderland.blinry.org/|
+|[01:39](https://www.bilibili.com/video/av214334199?t=99)|LiveTerm｜开发终端风格网站|https://liveterm.vercel.app/|
+|[01:56](https://www.bilibili.com/video/av214334199?t=116)|Datadog 介绍第三代事件存储库 Husky|https://www.datadoghq.com/blog/engineering/introducing-husky|
+|[02:16](https://www.bilibili.com/video/av214334199?t=136)|Quastor｜一个汇集大厂架构分析的专栏频道|https://quastor.substack.com/|
+
+## [视频链接](https://www.bilibili.com/video/av939044423)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1fu41167ME?t=9)|Clinic.js｜ Node.js 性能分析工具|https://clinicjs.org/|
-|[00:25](https://www.bilibili.com/video/BV1fu41167ME?t=25)|magic-trace｜Jane Street 开源的进程监控工具|https://github.com/janestreet/magic-trace|
-|[00:49](https://www.bilibili.com/video/BV1fu41167ME?t=49)|memray｜Bloomberg 开源的 Python 性能分析工具|https://github.com/bloomberg/memray|
-|[01:12](https://www.bilibili.com/video/BV1fu41167ME?t=72)|《learn GO with Tests》｜练习 GO 的工具书|https://quii.gitbook.io/learn-go-with-tests/go-fundamentals/hello-world|
-|[01:31](https://www.bilibili.com/video/BV1fu41167ME?t=91)|Edge Function｜Netlify 新推出的 PaaS 平台|https://www.netlify.com/blog/announcing-serverless-compute-with-edge-functions|
-|[01:56](https://www.bilibili.com/video/BV1fu41167ME?t=116)|workmode｜远程工作助手|https://workmode.co/|
-|[02:25](https://www.bilibili.com/video/BV1fu41167ME?t=145)|pixy｜飞行相机|https://pixy.com/|
-| |🍓本期 bgm｜Tango Bolero| |
-## [视频链接](https://www.bilibili.com/video/BV16B4y127vi)
+|[00:10](https://www.bilibili.com/video/av939044423?t=10)|BoltDB 作者的博客｜如何在 fly.io 中使用 SQLite|https://fly.io/blog/all-in-on-sqlite-litestream|
+|[00:40](https://www.bilibili.com/video/av939044423?t=40)|Litestream｜ Sqlite 实时复制工具|https://github.com/benbjohnson/litestream|
+|[00:49](https://www.bilibili.com/video/av939044423?t=49)|Cloudflare 发布 D1|https://blog.cloudflare.com/introducing-d1/|
+|[01:21](https://www.bilibili.com/video/av939044423?t=81)|rqlite｜ 与 D1 相似的开源分布式数据库|https://github.com/rqlite/rqlite|
+|[01:33](https://www.bilibili.com/video/av939044423?t=93)|CaskDB｜一个 kv 存储引擎的教学工具|https://github.com/avinassh/py-caskdb|
+|[01:54](https://www.bilibili.com/video/av939044423?t=114)|CubeDesk｜魔方提速工具|https://www.cubedesk.io/home|
+|[02:16](https://www.bilibili.com/video/av939044423?t=136)|DFlex ｜一个适配所有 JS 框架的可拖拽的工具库|https://www.dflex.dev/|
+|[02:30](https://www.bilibili.com/video/av939044423?t=150)|一篇 JS 性能分析指南的文章|https://blog.atomrc.dev/p/js-performance-profiling/|
+
+## [视频链接](https://www.bilibili.com/video/av596334116)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:08](https://www.bilibili.com/video/BV16B4y127vi?t=8)|一个有用网站的合集| |
-|[00:24](https://www.bilibili.com/video/BV16B4y127vi?t=24)|一个开源的 web 文本编辑器| |
-|[00:44](https://www.bilibili.com/video/BV16B4y127vi?t=44)|一个开源的分布式数据库| |
-|[01:11](https://www.bilibili.com/video/BV16B4y127vi?t=71)|OpenRefine｜开源数据清洗工具| |
-|[01:31](https://www.bilibili.com/video/BV16B4y127vi?t=91)|Node.js 发布18版本| |
-|[01:47](https://www.bilibili.com/video/BV16B4y127vi?t=107)|GO 发表介绍泛型的文章| |
-|[02:03](https://www.bilibili.com/video/BV16B4y127vi?t=123)|一个单手键盘| |
-| |本期 bgm｜siberian summer| |
-## [视频链接](https://www.bilibili.com/video/BV1yi4y1U7Ms)
+|[00:09](https://www.bilibili.com/video/av596334116?t=9)|Anaconda 发布 PyScript｜浏览器中运行 Python|https://www.anaconda.com/blog/pyscript-python-in-the-browser|
+|[00:37](https://www.bilibili.com/video/av596334116?t=37)|JSONHERO｜JSON 可视化工具|https://jsonhero.io/j/JZw4Wx9Mgj6r/tree|
+|[00:52](https://www.bilibili.com/video/av596334116?t=52)|Spacedrive｜本地和云端同在的文件管理器|https://www.spacedrive.app/|
+|[01:10](https://www.bilibili.com/video/av596334116?t=70)|Bash-Oneliner｜一个事例仓库|https://github.com/onceupon/Bash-Oneliner|
+|[01:23](https://www.bilibili.com/video/av596334116?t=83)|Fig｜ 与 Warp 类似的终端|https://fig.io/|
+|[01:39](https://www.bilibili.com/video/av596334116?t=99)|nosleep｜避免电脑休眠的网页|https://nosleep.page/|
+|[02:00](https://www.bilibili.com/video/av596334116?t=120)|一篇关于 Golang 的文章|https://fasterthanli.me/articles/lies-we-tell-ourselves-to-keep-using-golang|
+|[02:21](https://www.bilibili.com/video/av596334116?t=141)|移植到 web 上的《塞尔达传说》|https://hoten.cc/blog/porting-zelda-classic-to-the-web|
+
+## [视频链接](https://www.bilibili.com/video/av511210837)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1yi4y1U7Ms?t=9)|现代 CLI 大全| |
-|[00:35](https://www.bilibili.com/video/BV1yi4y1U7Ms?t=35)|bore｜基于 Rust 的隧道工具| |
-|[00:53](https://www.bilibili.com/video/BV1yi4y1U7Ms?t=53)|WeekToDo｜本地计划管理工具| |
-|[01:09](https://www.bilibili.com/video/BV1yi4y1U7Ms?t=69)|Zas｜专注于 GO 和 Rust 的编辑器| |
-|[01:24](https://www.bilibili.com/video/BV1yi4y1U7Ms?t=84)|Pinry｜Pinterest 的开源替代品| |
-|[01:45](https://www.bilibili.com/video/BV1yi4y1U7Ms?t=105)|｜Deno 推出 FaaS 服务| |
-|[02:13](https://www.bilibili.com/video/BV1yi4y1U7Ms?t=133)|EIGHT COLORS ｜一个小游戏| |
-## [视频链接](https://www.bilibili.com/video/BV12i4y1D78x)
+|[00:09](https://www.bilibili.com/video/av511210837?t=9)|Clinic.js｜ Node.js 性能分析工具|https://clinicjs.org/|
+|[00:25](https://www.bilibili.com/video/av511210837?t=25)|magic-trace｜Jane Street 开源的进程监控工具|https://github.com/janestreet/magic-trace|
+|[00:49](https://www.bilibili.com/video/av511210837?t=49)|memray｜Bloomberg 开源的 Python 性能分析工具|https://github.com/bloomberg/memray|
+|[01:12](https://www.bilibili.com/video/av511210837?t=72)|《learn GO with Tests》｜练习 GO 的工具书|https://quii.gitbook.io/learn-go-with-tests/go-fundamentals/hello-world|
+|[01:31](https://www.bilibili.com/video/av511210837?t=91)|Edge Function｜Netlify 新推出的 PaaS 平台|https://www.netlify.com/blog/announcing-serverless-compute-with-edge-functions|
+|[01:56](https://www.bilibili.com/video/av511210837?t=116)|workmode｜远程工作助手|https://workmode.co/|
+|[02:25](https://www.bilibili.com/video/av511210837?t=145)|pixy｜飞行相机|https://pixy.com/|
+
+## [视频链接](https://www.bilibili.com/video/av595895504)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:11](https://www.bilibili.com/video/BV12i4y1D78x?t=11)|Coolify ｜自部署 PaaS| |
-|[00:29](https://www.bilibili.com/video/BV12i4y1D78x?t=29)|warp｜现代化终端| |
-|[00:48](https://www.bilibili.com/video/BV12i4y1D78x?t=48)|redo｜开源命令行工具| |
-|[00:59](https://www.bilibili.com/video/BV12i4y1D78x?t=59)|MetricFlow｜数据仓库管理工具| |
-|[01:15](https://www.bilibili.com/video/BV12i4y1D78x?t=75)|Ruby 增加 WASM 支持| |
-|[01:41](https://www.bilibili.com/video/BV12i4y1D78x?t=101)|Rome 发布 Rome Formatter｜对标 Prettier| |
-|[02:04](https://www.bilibili.com/video/BV12i4y1D78x?t=124)|一篇博客｜TypeScript 编译器工作原理| |
-|[02:18](https://www.bilibili.com/video/BV12i4y1D78x?t=138)|一篇博客｜ 一些易被忽略的 HTML 属性| |
-## [视频链接](https://www.bilibili.com/video/BV1aF41137oA)
+|[00:08](https://www.bilibili.com/video/av595895504?t=8)|一个有用网站的合集| |
+|[00:24](https://www.bilibili.com/video/av595895504?t=24)|一个开源的 web 文本编辑器| |
+|[00:44](https://www.bilibili.com/video/av595895504?t=44)|一个开源的分布式数据库| |
+|[01:11](https://www.bilibili.com/video/av595895504?t=71)|OpenRefine｜开源数据清洗工具| |
+|[01:31](https://www.bilibili.com/video/av595895504?t=91)|Node.js 发布18版本| |
+|[01:47](https://www.bilibili.com/video/av595895504?t=107)|GO 发表介绍泛型的文章| |
+|[02:03](https://www.bilibili.com/video/av595895504?t=123)|一个单手键盘| |
+
+## [视频链接](https://www.bilibili.com/video/av553253895)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1aF41137oA?t=9)|GitHub issues 打印机| |
-|[00:29](https://www.bilibili.com/video/BV1aF41137oA?t=29)|Oh heck｜一个智能终端指令输入工具| |
-|[00:52](https://www.bilibili.com/video/BV1aF41137oA?t=52)|dagger｜一个现代化的 CI/CD 工具包| |
-|[01:11](https://www.bilibili.com/video/BV1aF41137oA?t=71)|React 发布18.0版本| |
-|[01:22](https://www.bilibili.com/video/BV1aF41137oA?t=82)|Chrome Experiments 的银河系实验| |
-|[01:40](https://www.bilibili.com/video/BV1aF41137oA?t=100)|arpchat｜用 ARP 协议实现的在线聊天工具| |
-|[02:03](https://www.bilibili.com/video/BV1aF41137oA?t=123)|Calenday｜ 一个多人共享日历| |
-|[02:21](https://www.bilibili.com/video/BV1aF41137oA?t=141)|WebAssembly 运行 Python| |
-|[02:49](https://www.bilibili.com/video/BV1aF41137oA?t=169)|Blog Search｜技术类搜索引擎| |
-## [视频链接](https://www.bilibili.com/video/BV19S4y127wz)
+|[00:09](https://www.bilibili.com/video/av553253895?t=9)|现代 CLI 大全| |
+|[00:35](https://www.bilibili.com/video/av553253895?t=35)|bore｜基于 Rust 的隧道工具| |
+|[00:53](https://www.bilibili.com/video/av553253895?t=53)|WeekToDo｜本地计划管理工具| |
+|[01:09](https://www.bilibili.com/video/av553253895?t=69)|Zas｜专注于 GO 和 Rust 的编辑器| |
+|[01:24](https://www.bilibili.com/video/av553253895?t=84)|Pinry｜Pinterest 的开源替代品| |
+|[01:45](https://www.bilibili.com/video/av553253895?t=105)|｜Deno 推出 FaaS 服务| |
+|[02:13](https://www.bilibili.com/video/av553253895?t=133)|EIGHT COLORS ｜一个小游戏| |
+
+## [视频链接](https://www.bilibili.com/video/av553093356)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:08](https://www.bilibili.com/video/BV19S4y127wz?t=8)|appwrite｜为 web、mobile 和 flutter 开发者提供的开源后端服务| |
-|[00:37](https://www.bilibili.com/video/BV19S4y127wz?t=37)|Bionic Reading｜一个用高亮标注的阅读工具| |
-|[01:04](https://www.bilibili.com/video/BV19S4y127wz?t=64)|diagrams.net ｜老牌绘图工具更新功能| |
-|[01:19](https://www.bilibili.com/video/BV19S4y127wz?t=79)|Smort｜一个可编辑其它网站文章的工具| |
-|[01:49](https://www.bilibili.com/video/BV19S4y127wz?t=109)|fzf｜命令行中通用的模糊查询工具| |
-|[01:57](https://www.bilibili.com/video/BV19S4y127wz?t=117)|一个 node.js 的 Postgres 数据库客户端| |
-|[02:07](https://www.bilibili.com/video/BV19S4y127wz?t=127)|mdn 推出 plus 订阅计划｜Mozilla 商业化新尝试| |
-|[02:45](https://www.bilibili.com/video/BV19S4y127wz?t=165)|一篇题为 《Data Mesh 架构》的文章| |
-## [视频链接](https://www.bilibili.com/video/BV1HU4y1d7da)
+|[00:11](https://www.bilibili.com/video/av553093356?t=11)|Coolify ｜自部署 PaaS| |
+|[00:29](https://www.bilibili.com/video/av553093356?t=29)|warp｜现代化终端| |
+|[00:48](https://www.bilibili.com/video/av553093356?t=48)|redo｜开源命令行工具| |
+|[00:59](https://www.bilibili.com/video/av553093356?t=59)|MetricFlow｜数据仓库管理工具| |
+|[01:15](https://www.bilibili.com/video/av553093356?t=75)|Ruby 增加 WASM 支持| |
+|[01:41](https://www.bilibili.com/video/av553093356?t=101)|Rome 发布 Rome Formatter｜对标 Prettier| |
+|[02:04](https://www.bilibili.com/video/av553093356?t=124)|一篇博客｜TypeScript 编译器工作原理| |
+|[02:18](https://www.bilibili.com/video/av553093356?t=138)|一篇博客｜ 一些易被忽略的 HTML 属性| |
+
+## [视频链接](https://www.bilibili.com/video/av297873494)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:08](https://www.bilibili.com/video/BV1HU4y1d7da?t=8)|文献管理工具 Zotero 发布 6.0 版本| |
-|[00:25](https://www.bilibili.com/video/BV1HU4y1d7da?t=25)|Plasticity ｜ 用 web 开发的3D 艺术建模开源软件| |
-|[00:55](https://www.bilibili.com/video/BV1HU4y1d7da?t=55)|Lapce ｜基于原生 GUI 和 Rust 编写的开源代码编辑器| |
-|[01:17](https://www.bilibili.com/video/BV1HU4y1d7da?t=77)|Awesome TUIs｜ 收集提供终端用户界面项目清单| |
-|[01:36](https://www.bilibili.com/video/BV1HU4y1d7da?t=96)|K9s ｜一个终端中 UI 强大的 K8s 客户端| |
-|[01:43](https://www.bilibili.com/video/BV1HU4y1d7da?t=103)|Tiny renderer｜500 行代码学习 openGL｜附演示教程| |
-|[02:00](https://www.bilibili.com/video/BV1HU4y1d7da?t=120)|GO 发布1.18版本支持泛型| |
-|[02:14](https://www.bilibili.com/video/BV1HU4y1d7da?t=134)|CSS-Tricks 网站被 DigitalOcean 收购| |
-|[02:35](https://www.bilibili.com/video/BV1HU4y1d7da?t=155)|Veloren ｜一个基于 Rust 开发的开源多人 RPG 游戏| |
-## [视频链接](https://www.bilibili.com/video/BV1VS4y1D768)
+|[00:09](https://www.bilibili.com/video/av297873494?t=9)|GitHub issues 打印机| |
+|[00:29](https://www.bilibili.com/video/av297873494?t=29)|Oh heck｜一个智能终端指令输入工具| |
+|[00:52](https://www.bilibili.com/video/av297873494?t=52)|dagger｜一个现代化的 CI/CD 工具包| |
+|[01:11](https://www.bilibili.com/video/av297873494?t=71)|React 发布18.0版本| |
+|[01:22](https://www.bilibili.com/video/av297873494?t=82)|Chrome Experiments 的银河系实验| |
+|[01:40](https://www.bilibili.com/video/av297873494?t=100)|arpchat｜用 ARP 协议实现的在线聊天工具| |
+|[02:03](https://www.bilibili.com/video/av297873494?t=123)|Calenday｜ 一个多人共享日历| |
+|[02:21](https://www.bilibili.com/video/av297873494?t=141)|WebAssembly 运行 Python| |
+|[02:49](https://www.bilibili.com/video/av297873494?t=169)|Blog Search｜技术类搜索引擎| |
+
+## [视频链接](https://www.bilibili.com/video/av725137289)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:08](https://www.bilibili.com/video/BV1VS4y1D768?t=8)|关于 TypeScript 的两条新闻| |
-|[00:21](https://www.bilibili.com/video/BV1VS4y1D768?t=21)|TypeScript 向 JS 提议增加类型系统| |
-|[00:40](https://www.bilibili.com/video/BV1VS4y1D768?t=40)|Stripe 将 JS 代码库从 Flow 迁移到 TypeScript| |
-|[01:17](https://www.bilibili.com/video/BV1VS4y1D768?t=77)|Godot ｜一个开源游戏引擎| |
-|[01:41](https://www.bilibili.com/video/BV1VS4y1D768?t=101)|苹果将发售 Mac Studio｜M1 芯片成为新杀手锏| |
-|[01:58](https://www.bilibili.com/video/BV1VS4y1D768?t=118)|关于数据库索引工作原理的解答| |
-|[02:24](https://www.bilibili.com/video/BV1VS4y1D768?t=144)|dasel ｜单一工具完成 JSON、TOML 等文件的读取和修改| |
-|[02:45](https://www.bilibili.com/video/BV1VS4y1D768?t=165)|“请停止使用 :latest 标签”｜一篇关于版本安全的文章| |
-## [视频链接](https://www.bilibili.com/video/BV1Y34y1b7cJ)
+|[00:08](https://www.bilibili.com/video/av725137289?t=8)|appwrite｜为 web、mobile 和 flutter 开发者提供的开源后端服务| |
+|[00:37](https://www.bilibili.com/video/av725137289?t=37)|Bionic Reading｜一个用高亮标注的阅读工具| |
+|[01:04](https://www.bilibili.com/video/av725137289?t=64)|diagrams.net ｜老牌绘图工具更新功能| |
+|[01:19](https://www.bilibili.com/video/av725137289?t=79)|Smort｜一个可编辑其它网站文章的工具| |
+|[01:49](https://www.bilibili.com/video/av725137289?t=109)|fzf｜命令行中通用的模糊查询工具| |
+|[01:57](https://www.bilibili.com/video/av725137289?t=117)|一个 node.js 的 Postgres 数据库客户端| |
+|[02:07](https://www.bilibili.com/video/av725137289?t=127)|mdn 推出 plus 订阅计划｜Mozilla 商业化新尝试| |
+|[02:45](https://www.bilibili.com/video/av725137289?t=165)|一篇题为 《Data Mesh 架构》的文章| |
+
+## [视频链接](https://www.bilibili.com/video/av682476244)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:08](https://www.bilibili.com/video/BV1Y34y1b7cJ?t=8)|Mozilla 的 MDN 文档全新上线| |
-|[00:41](https://www.bilibili.com/video/BV1Y34y1b7cJ?t=41)|Mozilla 的3D虚拟空间产品| |
-|[01:01](https://www.bilibili.com/video/BV1Y34y1b7cJ?t=61)|HOPPSCOTCH ｜一个开源网络请求发送工具| |
-|[01:19](https://www.bilibili.com/video/BV1Y34y1b7cJ?t=79)|Streamlit ｜一个使用 Python 直接开发 web UI 的工具| |
-|[01:42](https://www.bilibili.com/video/BV1Y34y1b7cJ?t=102)|Textframe ｜一个动画产品教程创建工具| |
-|[01:59](https://www.bilibili.com/video/BV1Y34y1b7cJ?t=119)|SaaS 产品开源替代品大全| |
-|[02:30](https://www.bilibili.com/video/BV1Y34y1b7cJ?t=150)|迷你掌上游戏机 playdate 开源了 SDK| |
-|[02:52](https://www.bilibili.com/video/BV1Y34y1b7cJ?t=172)|轻松一刻时间｜小游戏| |
-## [视频链接](https://www.bilibili.com/video/BV1m34y1r7EY)
+|[00:08](https://www.bilibili.com/video/av682476244?t=8)|文献管理工具 Zotero 发布 6.0 版本| |
+|[00:25](https://www.bilibili.com/video/av682476244?t=25)|Plasticity ｜ 用 web 开发的3D 艺术建模开源软件| |
+|[00:55](https://www.bilibili.com/video/av682476244?t=55)|Lapce ｜基于原生 GUI 和 Rust 编写的开源代码编辑器| |
+|[01:17](https://www.bilibili.com/video/av682476244?t=77)|Awesome TUIs｜ 收集提供终端用户界面项目清单| |
+|[01:36](https://www.bilibili.com/video/av682476244?t=96)|K9s ｜一个终端中 UI 强大的 K8s 客户端| |
+|[01:43](https://www.bilibili.com/video/av682476244?t=103)|Tiny renderer｜500 行代码学习 openGL｜附演示教程| |
+|[02:00](https://www.bilibili.com/video/av682476244?t=120)|GO 发布1.18版本支持泛型| |
+|[02:14](https://www.bilibili.com/video/av682476244?t=134)|CSS-Tricks 网站被 DigitalOcean 收购| |
+|[02:35](https://www.bilibili.com/video/av682476244?t=155)|Veloren ｜一个基于 Rust 开发的开源多人 RPG 游戏| |
+
+## [视频链接](https://www.bilibili.com/video/av724739860)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1m34y1r7EY?t=9)|怎样实现一个最简单的 CRUD 应用？｜本期专题问答| |
-|[00:32](https://www.bilibili.com/video/BV1m34y1r7EY?t=32)|Django｜CRUD 最佳工具/答案1| |
-|[00:49](https://www.bilibili.com/video/BV1m34y1r7EY?t=49)|PostgREST｜CRUD 最佳工具/答案2| |
-|[01:19](https://www.bilibili.com/video/BV1m34y1r7EY?t=79)|nHOST｜CRUD 最佳工具/答案3| |
-|[01:45](https://www.bilibili.com/video/BV1m34y1r7EY?t=105)|Grist｜Airtable 的开源替代| |
-|[02:06](https://www.bilibili.com/video/BV1m34y1r7EY?t=126)|Automerge｜JS 协同算法库| |
-|[02:34](https://www.bilibili.com/video/BV1m34y1r7EY?t=154)|Supernotes｜笔记软件| |
-|[02:45](https://www.bilibili.com/video/BV1m34y1r7EY?t=165)|Sioyek｜论文专用 PDF 阅读器| |
-## [视频链接](https://www.bilibili.com/video/BV19P4y1F7s7)
+|[00:08](https://www.bilibili.com/video/av724739860?t=8)|关于 TypeScript 的两条新闻| |
+|[00:21](https://www.bilibili.com/video/av724739860?t=21)|TypeScript 向 JS 提议增加类型系统| |
+|[00:40](https://www.bilibili.com/video/av724739860?t=40)|Stripe 将 JS 代码库从 Flow 迁移到 TypeScript| |
+|[01:17](https://www.bilibili.com/video/av724739860?t=77)|Godot ｜一个开源游戏引擎| |
+|[01:41](https://www.bilibili.com/video/av724739860?t=101)|苹果将发售 Mac Studio｜M1 芯片成为新杀手锏| |
+|[01:58](https://www.bilibili.com/video/av724739860?t=118)|关于数据库索引工作原理的解答| |
+|[02:24](https://www.bilibili.com/video/av724739860?t=144)|dasel ｜单一工具完成 JSON、TOML 等文件的读取和修改| |
+|[02:45](https://www.bilibili.com/video/av724739860?t=165)|“请停止使用 :latest 标签”｜一篇关于版本安全的文章| |
+
+## [视频链接](https://www.bilibili.com/video/av809507046)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-## [视频链接](https://www.bilibili.com/video/BV16a411y7fw)
+|[00:08](https://www.bilibili.com/video/av809507046?t=8)|Mozilla 的 MDN 文档全新上线| |
+|[00:41](https://www.bilibili.com/video/av809507046?t=41)|Mozilla 的3D虚拟空间产品| |
+|[01:01](https://www.bilibili.com/video/av809507046?t=61)|HOPPSCOTCH ｜一个开源网络请求发送工具| |
+|[01:19](https://www.bilibili.com/video/av809507046?t=79)|Streamlit ｜一个使用 Python 直接开发 web UI 的工具| |
+|[01:42](https://www.bilibili.com/video/av809507046?t=102)|Textframe ｜一个动画产品教程创建工具| |
+|[01:59](https://www.bilibili.com/video/av809507046?t=119)|SaaS 产品开源替代品大全| |
+|[02:30](https://www.bilibili.com/video/av809507046?t=150)|迷你掌上游戏机 playdate 开源了 SDK| |
+|[02:52](https://www.bilibili.com/video/av809507046?t=172)|轻松一刻时间｜小游戏| |
+
+## [视频链接](https://www.bilibili.com/video/av809272615)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV16a411y7fw?t=9)|Files Gallery｜应用| |
-|[00:22](https://www.bilibili.com/video/BV16a411y7fw?t=22)|Tally｜工具| |
-|[00:40](https://www.bilibili.com/video/BV16a411y7fw?t=40)|Datawrapper｜工具| |
-|[01:04](https://www.bilibili.com/video/BV16a411y7fw?t=64)|onemodel｜工具| |
-|[01:20](https://www.bilibili.com/video/BV16a411y7fw?t=80)|Postman｜工具| |
-|[01:29](https://www.bilibili.com/video/BV16a411y7fw?t=89)|Laravel 9.0 发布| |
-|[01:46](https://www.bilibili.com/video/BV16a411y7fw?t=106)|Mailwind｜邮件模版| |
-|[02:05](https://www.bilibili.com/video/BV16a411y7fw?t=125)|backend.sql + frontend.js = love》｜文章| |
-|[02:25](https://www.bilibili.com/video/BV16a411y7fw?t=145)|《Top web hacking techniques of 2021》｜文章| |
-|[02:41](https://www.bilibili.com/video/BV16a411y7fw?t=161)|SHA256 算法可视化演示| |
-## [视频链接](https://www.bilibili.com/video/BV1AT4y127tr)
+|[00:09](https://www.bilibili.com/video/av809272615?t=9)|怎样实现一个最简单的 CRUD 应用？｜本期专题问答| |
+|[00:32](https://www.bilibili.com/video/av809272615?t=32)|Django｜CRUD 最佳工具/答案1| |
+|[00:49](https://www.bilibili.com/video/av809272615?t=49)|PostgREST｜CRUD 最佳工具/答案2| |
+|[01:19](https://www.bilibili.com/video/av809272615?t=79)|nHOST｜CRUD 最佳工具/答案3| |
+|[01:45](https://www.bilibili.com/video/av809272615?t=105)|Grist｜Airtable 的开源替代| |
+|[02:06](https://www.bilibili.com/video/av809272615?t=126)|Automerge｜JS 协同算法库| |
+|[02:34](https://www.bilibili.com/video/av809272615?t=154)|Supernotes｜笔记软件| |
+|[02:45](https://www.bilibili.com/video/av809272615?t=165)|Sioyek｜论文专用 PDF 阅读器| |
+
+## [视频链接](https://www.bilibili.com/video/av894239914)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:08](https://www.bilibili.com/video/BV1AT4y127tr?t=8)|faker.js 删库事件新进展| |
-|[00:37](https://www.bilibili.com/video/BV1AT4y127tr?t=37)|暴雪被收购| |
-|[01:00](https://www.bilibili.com/video/BV1AT4y127tr?t=60)|PyFlow｜一个可视化编程环境| |
-|[01:14](https://www.bilibili.com/video/BV1AT4y127tr?t=74)|CSS 选择器练习题网站| |
-|[01:27](https://www.bilibili.com/video/BV1AT4y127tr?t=87)|GPS 工作原理详解| |
-|[01:47](https://www.bilibili.com/video/BV1AT4y127tr?t=107)|Lichess ｜ 一个国际象棋服务器的支出分析| |
-|[02:25](https://www.bilibili.com/video/BV1AT4y127tr?t=145)|谷歌分析在欧盟合法性及其替代品| |
-|[02:53](https://www.bilibili.com/video/BV1AT4y127tr?t=173)|AWS DynamoDB 十年回顾| |
-|[03:18](https://www.bilibili.com/video/BV1AT4y127tr?t=198)|CyberChef ｜ 一个数据格式转换工具| |
-|[03:32](https://www.bilibili.com/video/BV1AT4y127tr?t=212)|curl ｜ 最近支持了 JSON| |
-|[03:42](https://www.bilibili.com/video/BV1AT4y127tr?t=222)|轻松一刻｜弹珠撞击木块游戏| |
-## [视频链接](https://www.bilibili.com/video/BV1eT4y117Xh)
+
+## [视频链接](https://www.bilibili.com/video/av211446987)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:07](https://www.bilibili.com/video/BV1eT4y117Xh?t=7)|开源软件被植入恶意代码| |
-|[00:38](https://www.bilibili.com/video/BV1eT4y117Xh?t=38)|Browsix 浏览器中实现 POSIX| |
-|[01:09](https://www.bilibili.com/video/BV1eT4y117Xh?t=69)|GitHub Copilot| |
-|[01:29](https://www.bilibili.com/video/BV1eT4y117Xh?t=89)|Learn and Test DMARC 一个可视化工具| |
-|[01:46](https://www.bilibili.com/video/BV1eT4y117Xh?t=106)|BookStack 一个开源 wiki 工具| |
-|[02:06](https://www.bilibili.com/video/BV1eT4y117Xh?t=126)|Poly Haven 如何花不到400美金处理80TB数据和500万次页面访问的| |
-|[03:33](https://www.bilibili.com/video/BV1eT4y117Xh?t=213)|Kogi 一个新型高级付费搜索引擎| |
-|[04:07](https://www.bilibili.com/video/BV1eT4y117Xh?t=247)|介绍两个 Cli 工具: dsq 和 fx| |
-|[04:38](https://www.bilibili.com/video/BV1eT4y117Xh?t=278)|轻松一刻时间｜介绍一个打发时间的小游戏| |
-## [视频链接](https://www.bilibili.com/video/BV1vL4y1b78S)
+|[00:09](https://www.bilibili.com/video/av211446987?t=9)|Files Gallery｜应用| |
+|[00:22](https://www.bilibili.com/video/av211446987?t=22)|Tally｜工具| |
+|[00:40](https://www.bilibili.com/video/av211446987?t=40)|Datawrapper｜工具| |
+|[01:04](https://www.bilibili.com/video/av211446987?t=64)|onemodel｜工具| |
+|[01:20](https://www.bilibili.com/video/av211446987?t=80)|Postman｜工具| |
+|[01:29](https://www.bilibili.com/video/av211446987?t=89)|Laravel 9.0 发布| |
+|[01:46](https://www.bilibili.com/video/av211446987?t=106)|Mailwind｜邮件模版| |
+|[02:05](https://www.bilibili.com/video/av211446987?t=125)|《 backend.sql + frontend.js = love》｜文章| |
+|[02:25](https://www.bilibili.com/video/av211446987?t=145)|《Top web hacking techniques of 2021》｜文章| |
+|[02:41](https://www.bilibili.com/video/av211446987?t=161)|SHA256 算法可视化演示| |
+
+## [视频链接](https://www.bilibili.com/video/av851363567)
 
 |时间轴|简介|链接|
 |:--:|:--:|:--:|
-|[00:09](https://www.bilibili.com/video/BV1vL4y1b78S?t=9)|任天堂掌上游戏机发展史回顾| |
-|[01:10](https://www.bilibili.com/video/BV1vL4y1b78S?t=70)|《为什么要运行自己的 DNS 服务器？》| |
-|[01:31](https://www.bilibili.com/video/BV1vL4y1b78S?t=91)|Zotero，一个开源的经典文献管理工具| |
-|[01:57](https://www.bilibili.com/video/BV1vL4y1b78S?t=117)|Darling，一个帮助你在 Linux 上运行 Mac 应用程序的工具| |
-|[02:16](https://www.bilibili.com/video/BV1vL4y1b78S?t=136)|coqui，克隆你的声音说外语| |
-|[02:35](https://www.bilibili.com/video/BV1vL4y1b78S?t=155)|OpenDrop, 一个开源版的 AirDrop| |
-|[02:53](https://www.bilibili.com/video/BV1vL4y1b78S?t=173)|Portmaster，一个帮助你管理电脑网络的开源软件| |
-|[03:20](https://www.bilibili.com/video/BV1vL4y1b78S?t=200)|Papers We Love，一个专门研读学术类计算机科学论文的开源社区| |
-|[03:42](https://www.bilibili.com/video/BV1vL4y1b78S?t=222)|关于 Zig 这个新兴编程语言的分析| |
-|[04:14](https://www.bilibili.com/video/BV1vL4y1b78S?t=254)|Raycast 团队信奉无需 code review 的理念| |
-|[04:50](https://www.bilibili.com/video/BV1vL4y1b78S?t=290)|利用浏览器 web GL 实现的东京地铁实时可视化地图| |
-|[05:13](https://www.bilibili.com/video/BV1vL4y1b78S?t=313)|SpaceX Dragon 2 与国际空间站对接的模拟机| |
+
+## [视频链接](https://www.bilibili.com/video/av808652802)
+
+|时间轴|简介|链接|
+|:--:|:--:|:--:|
+
+## [视频链接](https://www.bilibili.com/video/av935758161)
+
+|时间轴|简介|链接|
+|:--:|:--:|:--:|
+|[00:08](https://www.bilibili.com/video/av935758161?t=8)|faker.js 删库事件新进展| |
+|[00:37](https://www.bilibili.com/video/av935758161?t=37)|暴雪被收购| |
+|[01:00](https://www.bilibili.com/video/av935758161?t=60)|PyFlow｜一个可视化编程环境| |
+|[01:14](https://www.bilibili.com/video/av935758161?t=74)|CSS 选择器练习题网站| |
+|[01:27](https://www.bilibili.com/video/av935758161?t=87)|GPS 工作原理详解| |
+|[01:47](https://www.bilibili.com/video/av935758161?t=107)|Lichess ｜ 一个国际象棋服务器的支出分析| |
+|[02:25](https://www.bilibili.com/video/av935758161?t=145)|谷歌分析在欧盟合法性及其替代品| |
+|[02:53](https://www.bilibili.com/video/av935758161?t=173)|AWS DynamoDB 十年回顾| |
+|[03:18](https://www.bilibili.com/video/av935758161?t=198)|CyberChef ｜ 一个数据格式转换工具| |
+|[03:32](https://www.bilibili.com/video/av935758161?t=212)|curl ｜ 最近支持了 JSON| |
+|[03:42](https://www.bilibili.com/video/av935758161?t=222)|轻松一刻｜弹珠撞击木块游戏| |
+
+## [视频链接](https://www.bilibili.com/video/av935663579)
+
+|时间轴|简介|链接|
+|:--:|:--:|:--:|
+|[00:07](https://www.bilibili.com/video/av935663579?t=7)|开源软件被植入恶意代码| |
+|[00:38](https://www.bilibili.com/video/av935663579?t=38)|Browsix 浏览器中实现 POSIX| |
+|[01:09](https://www.bilibili.com/video/av935663579?t=69)|GitHub Copilot| |
+|[01:29](https://www.bilibili.com/video/av935663579?t=89)|Learn and Test DMARC 一个可视化工具| |
+|[01:46](https://www.bilibili.com/video/av935663579?t=106)|BookStack 一个开源 wiki 工具| |
+|[02:06](https://www.bilibili.com/video/av935663579?t=126)|Poly Haven 如何花不到400美金处理80TB数据和500万次页面访问的| |
+|[03:33](https://www.bilibili.com/video/av935663579?t=213)|Kogi 一个新型高级付费搜索引擎| |
+|[04:07](https://www.bilibili.com/video/av935663579?t=247)|介绍两个 Cli 工具: dsq 和 fx| |
+|[04:38](https://www.bilibili.com/video/av935663579?t=278)|轻松一刻时间｜介绍一个打发时间的小游戏| |
+
+## [视频链接](https://www.bilibili.com/video/av850617825)
+
+|时间轴|简介|链接|
+|:--:|:--:|:--:|
+|[00:09](https://www.bilibili.com/video/av850617825?t=9)|任天堂掌上游戏机发展史回顾| |
+|[01:10](https://www.bilibili.com/video/av850617825?t=70)|《为什么要运行自己的 DNS 服务器？》| |
+|[01:31](https://www.bilibili.com/video/av850617825?t=91)|Zotero，一个开源的经典文献管理工具| |
+|[01:57](https://www.bilibili.com/video/av850617825?t=117)|Darling，一个帮助你在 Linux 上运行 Mac 应用程序的工具| |
+|[02:16](https://www.bilibili.com/video/av850617825?t=136)|coqui，克隆你的声音说外语| |
+|[02:35](https://www.bilibili.com/video/av850617825?t=155)|OpenDrop, 一个开源版的 AirDrop| |
+|[02:53](https://www.bilibili.com/video/av850617825?t=173)|Portmaster，一个帮助你管理电脑网络的开源软件| |
+|[03:20](https://www.bilibili.com/video/av850617825?t=200)|Papers We Love，一个专门研读学术类计算机科学论文的开源社区| |
+|[03:42](https://www.bilibili.com/video/av850617825?t=222)|关于 Zig 这个新兴编程语言的分析| |
+|[04:14](https://www.bilibili.com/video/av850617825?t=254)|Raycast 团队信奉无需 code review 的理念| |
+|[04:50](https://www.bilibili.com/video/av850617825?t=290)|利用浏览器 web GL 实现的东京地铁实时可视化地图| |
+|[05:13](https://www.bilibili.com/video/av850617825?t=313)|SpaceX Dragon 2 与国际空间站对接的模拟机| |
+
+## [视频链接](https://www.bilibili.com/video/av722854302)
+
+|时间轴|简介|链接|
+|:--:|:--:|:--:|
+
+## [视频链接](https://www.bilibili.com/video/av465206549)
+
+|时间轴|简介|链接|
+|:--:|:--:|:--:|

--- a/data.json
+++ b/data.json
@@ -1,1 +1,1955 @@
-[{"message": "本期时间轴：\n00:09 sharing｜将电脑中的文件通过二维码分享给手机\n00:31 Steampipe｜ 浏览云服务资产的交互式命令行工具\n00:54 Horizon UI｜ 基于 Chakra UI 的管理后台模版\n01:16 Postgres WASM｜ 开源 WASM 运行 PostgresSQL 方案\n01:50 v86｜ 通过 WebAssembly 运行 x86 兼容的虚拟机\n02:06  libSQL｜ SQLite 下游版本\n02:38 TypeScript  10 years anniversary \nBam｜Wingsuit Flying by Michele Nobler\n本期项目链接：\nhttps://github.com/parvardegr/sharing \nhttps://steampipe.io/ \nhttps://horizon-ui.com/ \nhttps://supabase.com/blog/postgres-wasm \nhttps://github.com/copy/v86\nhttps://github.com/libsql/libsql & https://itnext.io/sqlite-qemu-all-over-again-aedad19c9a1c \nhttps://devblogs.microsoft.com/typescript/ten-years-of-typescript/", "plat": 0, "device": "", "members": [], "jump_url": {"wasm": {"title": "wasm", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=wasm", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=wasm", "icon_position": 1}}, "max_line": 6, "bvid": "BV1GR4y1R7Yw"},{"message": "本期时间轴：\n00:09 SigNoz｜开源的 APM 系统\n00:35 Wails｜使用 Go 和 Web 技术开发桌面端应用\n00:58 CloudFlare 开源 serverless 运行时 workerd\n01:33 Qwik｜builder.io 开源的前端框架\n02:02 pdfgrep｜命令行搜索工具\n02:16 Liqe｜轻量级搜索引擎\n02:31 Google 计划关停云游戏服务 Stadia\nBam｜Théâtre dombres chinois by Biba Dupont \n本期项目链接：\nhttps://github.com/SigNoz/signoz\nhttps://wails.io/ \nhttps://github.com/cloudflare/workerd\nhttps://qwik.builder.io/\nhttps://pdfgrep.org/\nhttps://github.com/gajus/liqe\nhttps://www.theverge.com/2022/9/29/23378713/google-stadia-shutting-down-game-streaming-january-2023", "plat": 0, "device": "", "members": [], "jump_url": {"Dupont": {"title": "Dupont", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Dupont", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Dupont", "icon_position": 1}}, "max_line": 6, "bvid": "BV1td4y1B7Y1"},{"message": "本期时间轴：\n00:09 GitUI｜Git 终端 UI\n00:35 Dub｜开源短链接服务\n00:58 WunderBase｜ serverless GraphQL 数据库\n01:17 Rocketry｜现代化的 Python 调度框架\n01:33 KREA｜AI 作画图库\n01:55 Whisper｜ OpenAI 开源的语音识别系统\n02:15 fly.io 开源新项目 LiteFS \n02:51 Azure CTO Mark Russinovich 发推引发热议\nBam｜Tornado by Liron Meyuhas; Tea Time by Ty Simon \n本期项目链接：\nhttps://github.com/extrawurst/gitui \nhttps://dub.sh/ \nhttps://github.com/wundergraph/wunderbase \nhttps://github.com/Miksus/rocketry \nhttps://www.krea.ai/ \nhttps://openai.com/blog/whisper \nhttps://fly.io/blog/introducing-litefs \nhttps://twitter.com/markrussinovich/status/1571995117233504257", "plat": 0, "device": "", "members": [], "jump_url": {"Python": {"title": "Python", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Python", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Python", "icon_position": 1}}, "max_line": 6, "bvid": "BV1Je4y1r7B4"},{"message": "本期时间轴：\n00:09 Figma 被收购引发在线设计工具新动向00:31 penpot｜开源设计工具因 Figma 变热\n00:46 Theatre.js｜开源在线动效编辑器\n01:08 Markdoc｜交互式 Markdown\n01:25 Meta 将 PyTorch 捐赠给 Linux 基金会\n01:37 Meta 发布了网页内存泄漏检测工具 MemLab\n01:59 SafeQL｜ 校验 SQL 的 ESLint 插件\n02:14 Diffusion Bee｜在 M1 Mac 上运行 Stable Diffusion 的桌面端应用\nBam｜Cool Cats by Family Kush\n本期项目链接：\nhttps://www.bloomberg.com/news/articles/2022-09-15/adobe-is-said-to-near-deal-to-buy-online-design-startup-figma\nhttps://penpot.app/\nhttps://www.theatrejs.com/\nhttps://markdoc.dev/\nhttps://www.linuxfoundation.org/blog/blog/welcoming-pytorch-to-the-linux-foundation\nhttps://engineering.fb.com/2022/09/12/open-source/memlab/\nhttps://safeql.dev/\nhttps://github.com/divamgupta/diffusionbee-stable-diffusion-ui", "plat": 0, "device": "", "members": [], "jump_url": {"figma": {"title": "figma", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=figma", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=figma", "icon_position": 1}}, "max_line": 6, "bvid": "BV1QP411H7rM"},{"message": "本期时间轴：\n00:11 Difftastic｜结构化 diff 工具\n00:46 ruff｜百倍快的 Python linter\n01:12 DataEase｜数据可视化分析工具\n01:36 MATHLIVE｜展示和编辑数学公式的 Web Component\n02:03 VSCheatsheet｜VS Code 快捷键合集\n02:24 Modern for Hacker News｜ 美化 Hacker News 界面的浏览器插件\n02:37 signals｜PREACT 状态管理新方案\nBam｜Shake That Fever by Duffmusiq\n本期项目链接：\nhttps://www.wilfred.me.uk/blog/2022/09/06/difftastic-the-fantastic-diff/ \nhttps://github.com/charliermarsh/ruff \nhttps://github.com/dataease/dataease \nhttps://cortexjs.io/mathlive \nhttps://www.vscheatsheet.com/ \nhttps://www.modernhn.com/ \nhttps://preactjs.com/blog/introducing-signals/", "plat": 0, "device": "", "members": [], "jump_url": {"wilfred": {"title": "wilfred", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=wilfred", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=wilfred", "icon_position": 1}}, "max_line": 6, "bvid": "BV1Pe4y187LV"},{"message": "本期时间轴：\n00:09 Devbox｜快速启动隔离开发环境\n00:38 绘图语言 D2\n00:52 YAO｜开发应用引擎\n01:20 JSON Crack｜JSON 可视化工具\n01:42 Motionity｜动效编辑器\n02:02 mvSQLite｜分布式 SQLite \n02:37 Heroku 即将停止免费额度\n03:01 GitHub 开发者关系副总裁回复移除 Trending \nBam: Don’t Let the Summer End by The Magnetic Buzz", "plat": 0, "device": "", "members": [], "jump_url": {"Heroku": {"title": "Heroku", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Heroku", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Heroku", "icon_position": 1}}, "max_line": 6, "bvid": "BV19e411g7qe"},{"message": "本期时间轴：00:09｜野心勃勃的数据库 SurrealDB\n00:38 Stable Diffusion｜开源的 AI 图片生成模型\n00:59 react-design-editor｜ Canva 的开源替代品\n01:24 Weylus｜将触屏设备变为触摸板\n01:43 eInk-VNC｜将 VMC 输出到墨水屏\n02:04 SQLite 并发读取性能详解\n02:26 80 岁计算机科学家仍在优化开源代码\n本期项目链接：\nhttps://surrealdb.com/ \nhttps://github.com/CompVis/stable-diffusion\nhttps://github.com/layerhub-io/react-design-editor\nhttps://github.com/H-M-H/Weylus\nhttps://zmarshall.nl/static/eink-vnc.html\nhttps://fly.io/blog/sqlite-internals-wal\nhttps://news.ycombinator.com/item?id=32534173\nbgm: Autumn by Tony Petersen", "plat": 0, "device": "", "members": [], "jump_url": {"Canva": {"title": "Canva", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Canva", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Canva", "icon_position": 1}}, "max_line": 6, "bvid": "BV1qa411G7kd"},{"message": "本期时间轴：\n00:10 Numpad ｜一个新式文本编辑器\n00:34 Erg｜与 Python 兼容的静态类型语言\n00:57 分布式文件系统 JuiceFS\n01:22 JiraCLI｜ 对 Jira 的命令行客户端\n01:33 Crunchy Data｜在浏览器中运行 Postgres\n01:53 JSON5 作者的一篇博客\n本期项目链接：\nhttps://numpad.io/\nhttps://github.com/erg-lang/erg\nhttps://github.com/juicedata/juicefs\nhttps://github.com/ankitpokhrel/jira-cli\nhttps://www.crunchydata.com/blog/learn-postgres-at-the-playground\nhttps://aseemk.substack.com/p/ignore-the-f-ing-haters-json5", "plat": 0, "device": "", "members": [], "jump_url": {"分布式文件": {"title": "分布式文件", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=分布式文件", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=分布式文件", "icon_position": 1}}, "max_line": 6, "bvid": "BV1bg411r7Fg"},{"message": "本期时间轴：\n00:09 远程开发方案 Coder\n00:34 高性能 virtual DOM\n01:04 Astro 发布了 1.0 版本\n01:28 Multy｜ 基于 Terraform 的跨云部署框架\n01:54 Rancher 创始团队运营新开源产品 Acorn\n02:21 一篇介绍 Redis 技术细节的文章\n本期项目链接：\nhttps://coder.com/  \nhttps://millionjs.org/\nhttps://astro.build/blog/astro-1/\nhttps://github.com/multycloud/multy\nhttps://acorn.io/\nhttps://architecturenotes.co/redis/", "plat": 0, "device": "", "members": [], "jump_url": {"Terraform": {"title": "Terraform", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Terraform", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Terraform", "icon_position": 1}}, "max_line": 6, "bvid": "BV1UB4y1t7cW"},{"message": "本期时间轴：\n00:08 开源知识库软件能否替代 Notion\n00:35 Copilot 开源替代品\n00:52 逆向工程工具箱\n01:08 Emery｜效率工具\n01:24 一篇介绍 eBPF 技术的文章\n01:50 用 DALL·E 2 生成 logo 图片的分享文章\n本期项目链接：\nhttps://github.com/toeverything/AFFiNE \nhttps://github.com/moyix/fauxpilot \nhttps://github.com/WerWolv/ImHex \nhttps://emery.to/ \nhttps://www.groundcover.com/blog/what-is-ebpf \nhttps://jacobmartins.com/posts/how-i-used-dalle2-to-generate-the-logo-for-octosql/", "plat": 0, "device": "", "members": [], "jump_url": {"Copilot": {"title": "Copilot", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Copilot", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Copilot", "icon_position": 1}}, "max_line": 6, "bvid": "BV1VN4y1j7Pd"},{"aid": 471440344},{"message": "本期时间轴：\n00:11 Google 发布新编程语言 Carbon\n00:58 榫卯｜ Sunmao ｜低代码工具开发框架\n01:40 Comcast｜模拟弱网环境的工具\n02:36 Tweakpane｜ 一个调节参数的 JS 库\n02:58 AI 系统 DALL·E 开放 Beta 测试\n03:21 一篇关于 Scratch 潜能的文章\n本期项目链接：\nhttps://github.com/carbon-language/carbon-lang \nhttps://github.com/smartxworks/sunmao-ui \nhttps://github.com/tylertreat/comcast \nhttps://cocopon.github.io/tweakpane/ \nhttps://openai.com/blog/dall-e-now-available-in-beta \nhttps://www.bryanbraun.com/2022/07/16/scratch-is-a-big-deal", "plat": 0, "device": "", "members": [], "jump_url": {}, "max_line": 6, "bvid": "BV1hV4y177P9"},{"message": "本期时间轴：\n00:12 Vite 发布3.0版本\n00:30 VictoriaMetrics｜Prometheus 的开源替代品\n01:02 对 Bun 和 Node.js 对比实测\n01:49 Cleanupphotos｜修图工具\n02:14 Vim 在线交互式学习平台\n02:36 推荐《PostgreSQL 14 Internals》一书\n本期项目链接：\nhttps://vitejs.dev/blog/announcing-vite3.html \nhttps://victoriametrics.com/products/open-source/ \nhttps://techsparx.com/nodejs/bun/1st-trial.html \nhttps://cleanupphotos.com/ \nhttps://www.vimified.com/ \nhttps://postgrespro.com/community/books/internals", "plat": 0, "device": "", "members": [], "jump_url": {"修图工具": {"title": "修图工具", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=修图工具", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=修图工具", "icon_position": 1}}, "max_line": 6, "bvid": "BV16N4y1T7Hu"},{"message": "本期时间轴：\n00:09 Bun｜高性能 JS 运行时 \n00:40 TAURI｜Electron 轻量级替代品\n01:02 Felt｜在线地图编辑网站\n01:19 PocketBase｜ 开源实时后端方案\n01:44 fuite｜自动探测 Web 应用内存泄漏\n02:05 一篇关于 rsync 工作原理的文章\n本期项目链接：\nhttps://bun.sh/ \nhttps://tauri.app/ \nhttps://felt.com/ \nhttps://pocketbase.io/ \nhttps://github.com/nolanlawson/fuite \nhttps://michael.stapelberg.ch/posts/2022-07-02-rsync-how-does-it-work", "plat": 0, "device": "", "members": [], "jump_url": {"Electron": {"title": "Electron", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Electron", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Electron", "icon_position": 1}}, "max_line": 6, "bvid": "BV1Wg411f7VV"},{"message": "本期时间轴：\n00:10 Pyroscope｜性能持续分析工具\n00:35 daisyUI｜前端组件库\n00:55 《数据库必须知道的那些事》\n01:21 《浏览器是如何工作的》\n01:49 Spark 与 K8s 集成新动向\n02:15 Raindrop｜书签管理小工具\n本期项目链接：\nhttps://pyroscope.io/ \nhttps://daisyui.com/ \nhttps://architecturenotes.co/things-you-should-know-about-databases \nhttps://web.dev/howbrowserswork/ \nhttps://www.cncf.io/blog/2022/06/30/why-spark-chooses-volcano-as-built-in-batch-scheduler-on-kubernetes/ \nhttps://raindrop.io/", "plat": 0, "device": "", "members": [], "jump_url": {"K8s": {"title": "K8s", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=K8s", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=K8s", "icon_position": 1}}, "max_line": 6, "bvid": "BV1Xr4y1M7T7"},{"message": "00:09 Github AI 代码助手 Copilot 正式发布\n00:46 Markone｜绘制时间轴的工具\n01:01 Viddy｜现代的 watch 替代品\n01:21 Elastic UI｜Elastic 开源的前端 UI 组件库\n01:49 Avo｜构建在 Ruby on Rails 方案之上的应用开发框架\n02:23 Unclutter｜整理网页的浏览器插件\n02:43 SQLite 发布 SQLite4 设计\n03:04 Deno 完成 A 轮融资\n本期项目链接：\nhttps://github.blog/2022-06-21-github-copilot-is-generally-available-to-all-developers/ \nhttps://markwhen.com/ \nhttps://github.com/sachaos/viddy \nhttps://elastic.github.io/eui/#/ \nhttps://avohq.io/ \nhttps://unclutter.lindylearn.io/ \nhttps://sqlite.org/src4/doc/trunk/www/design.wiki \nhttps://deno.com/blog/series-a", "plat": 0, "device": "", "members": [], "jump_url": {"copilot": {"title": "copilot", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=copilot", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=copilot", "icon_position": 1}}, "max_line": 6, "bvid": "BV1B3411u7ZG"},{"message": "00:09 FRESH｜Deno 原生 SSR Web 框架\n00:34 Vitest｜基于 vite 的单元测试框架\n00:55 Rulex｜新的正则表达式语言\n01:14 Recut｜视频剪辑工具\n01:31 moon｜构建工具\n01:46 一个寻找项目灵感的网站\n02:01  程序员社交新尝试", "plat": 0, "device": "", "members": [], "jump_url": {"视频剪辑工具": {"title": "视频剪辑工具", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=视频剪辑工具", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=视频剪辑工具", "icon_position": 1}}, "max_line": 6, "bvid": "BV1sY411T7QL"},{"message": "为方便小伙伴观看，可参见如下时间轴：\n00:09 Knight Lab｜用代码更好地讲故事\n00:30 plasmo｜浏览器插件开发平台\n00:49 Shotcut｜开源免费跨平台视频编辑器\n01:06 DEEPKIT｜Typescript 高性能框架\n01:24 opensourcealternative.to｜查找开源替代品的网站\n01:42 untools｜一组帮助思考的工具和方法论\n本期项目链接：\nhttps://knightlab.northwestern.edu/projects/ \nhttps://www.plasmo.com/ \nhttps://shotcut.org/ \nhttps://deepkit.io/ \nhttps://www.opensourcealternative.to/ \nhttps://untools.co/", "plat": 0, "device": "", "members": [], "jump_url": {"shotcut": {"title": "shotcut", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=shotcut", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=shotcut", "icon_position": 1}}, "max_line": 6, "bvid": "BV1rS4y1i72U"},{"message": "🍒为方便小伙伴观看，可参见如下时间轴：\n00:09 Dragonfly｜一个25倍快的 Redis 竞品\n00:50 PlantUML｜快速编写 UML 图\n01:12 Neon｜开源 serverless Postgres 方案\n01:39 ROAPI｜数据聚合 API\n02:18 Tetra｜一个全栈框架\n02:49 fd｜终端工具 Find 的替代品\n03:05 svelvet｜交互式关系图构建工具\n03:22 ffmpeg buddy｜FFmpeg 命令生成工具\n🍒本期项目链接：\nhttps://github.com/dragonflydb/dragonfly \nhttps://plantuml.com/ \nhttps://neon.tech/ \nhttps://github.com/roapi/roapi \nhttps://www.tetraframework.com/ \nhttps://github.com/sharkdp/fd \nhttps://svelvet.io/docs/basic-usage/ \nhttps://evanhahn.github.io/ffmpeg-buddy/", "plat": 0, "device": "", "members": [], "jump_url": {"plantuml": {"title": "plantuml", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=plantuml", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=plantuml", "icon_position": 1}}, "max_line": 6, "bvid": "BV1L34y1L7zK"},{"message": "为方便小伙伴观看，可参见如下时间轴：\n00:09 PikaScript | 超轻量级 Python 引擎\n00:26 bionic-reading 的快速阅读英文插件\n00:43 IndigoStack｜MacOS 平台上的本地开发环境\n01:03 TypeScript 发布4.7版本\n01:20 AnimatiSS｜一组 CSS 动画合集\n01:32 Arctype｜ SQL 数据库客户端\n01:47 一个有趣的3D 植物生成工具\n本期项目链接：\nhttps://github.com/pikasTech/pikascript \nhttps://github.com/ansh/bionic-reading \nhttps://indigostack.app/ \nhttps://devblogs.microsoft.com/typescript/announcing-typescript-4-7/ \nhttps://xsgames.co/animatiss \nhttps://arctype.com/ \nhttps://plant.jim-fx.com/", "plat": 0, "device": "", "members": [], "jump_url": {"bionic": {"title": "bionic", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=bionic", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=bionic", "icon_position": 1}}, "max_line": 6, "bvid": "BV1pY4y1z7Vx"},{"message": "🍒为方便小伙伴观看，可参见如下时间轴：\n00:09 Bud | GO 的全栈 web 框架\n00:38 Aspect | 可视化开发 React 组件\n00:57 在 SQLite 中使用 JSON 和 virtual columns\n01:17 Sliderland｜一个极简风格的 JS 实验园地\n01:39 LiveTerm｜开发终端风格网站\n01:56 Datadog 介绍第三代事件存储库 Husky\n02:16 Quastor｜一个汇集大厂架构分析的专栏频道\n🍒本期 bgm｜Pickin’ the Creep\n🍒本期项目链接：\nhttps://github.com/livebud/bud \nhttps://aspect.app/ \nhttps://antonz.org/json-virtual-columns \nhttps://sliderland.blinry.org/ \nhttps://liveterm.vercel.app/ \nhttps://www.datadoghq.com/blog/engineering/introducing-husky \nhttps://quastor.substack.com/", "plat": 0, "device": "", "members": [], "jump_url": {"husky": {"title": "husky", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=husky", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=husky", "icon_position": 1}}, "max_line": 6, "bvid": "BV13a411E7AQ"},{"message": "🍓为方便小伙伴观看，可参见如下时间轴：\n00:10  BoltDB 作者的博客｜如何在 fly.io 中使用 SQLite \n00:40 Litestream｜ Sqlite 实时复制工具\n00:49  Cloudflare 发布 D1\n01:21 rqlite｜ 与 D1 相似的开源分布式数据库\n01:33 CaskDB｜一个 kv 存储引擎的教学工具\n01:54 CubeDesk｜魔方提速工具\n02:16 DFlex ｜一个适配所有 JS 框架的可拖拽的工具库\n02:30 一篇 JS 性能分析指南的文章\n🍓本期 bgm｜ The Bahamas\n🍓本期项目链接：\nhttps://fly.io/blog/all-in-on-sqlite-litestream \nhttps://github.com/benbjohnson/litestream \nhttps://blog.cloudflare.com/introducing-d1/ \nhttps://github.com/rqlite/rqlite \nhttps://github.com/avinassh/py-caskdb \nhttps://www.cubedesk.io/home \nhttps://www.dflex.dev/ \nhttps://blog.atomrc.dev/p/js-performance-profiling/", "plat": 0, "device": "", "members": [], "jump_url": {"cloudflare": {"title": "cloudflare", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=cloudflare", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=cloudflare", "icon_position": 1}}, "max_line": 6, "bvid": "BV1kT4y1B7Nh"},{"message": "🍓为方便小伙伴们观看，可参见如下时间轴：\n00:09 Anaconda 发布 PyScript｜浏览器中运行 Python\n00:37 JSONHERO｜JSON 可视化工具\n00:52 Spacedrive｜本地和云端同在的文件管理器\n01:10 Bash-Oneliner｜一个事例仓库\n01:23 Fig｜ 与 Warp 类似的终端\n01:39 nosleep｜避免电脑休眠的网页\n02:00 一篇关于 Golang 的文章\n02:21 移植到 web 上的《塞尔达传说》\n🍓本期 bgm｜I don't get the lesson \n🍓本期项目链接：\nhttps://www.anaconda.com/blog/pyscript-python-in-the-browser \nhttps://jsonhero.io/j/JZw4Wx9Mgj6r/tree \nhttps://www.spacedrive.app/\nhttps://github.com/onceupon/Bash-Oneliner \nhttps://fig.io/ \nhttps://nosleep.page/ \nhttps://fasterthanli.me/articles/lies-we-tell-ourselves-to-keep-using-golang \nhttps://hoten.cc/blog/porting-zelda-classic-to-the-web", "plat": 0, "device": "", "members": [], "jump_url": {"pyscript": {"title": "pyscript", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=pyscript", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=pyscript", "icon_position": 1}}, "max_line": 6, "bvid": "BV1PB4y1278B"},{"message": "🍓为方便小伙伴观看，可参见如下时间轴：\n00:09 Clinic.js｜ Node.js 性能分析工具\n00:25 magic-trace｜Jane Street 开源的进程监控工具\n00:49 memray｜Bloomberg 开源的 Python 性能分析工具\n01:12 《learn GO with Tests》｜练习 GO 的工具书\n01:31  Edge Function｜Netlify 新推出的 PaaS 平台\n01:56 workmode｜远程工作助手\n02:25 pixy｜飞行相机\n🍓本期 bgm｜Tango Bolero\n🍓本期项目链接：\nhttps://clinicjs.org/ \nhttps://github.com/janestreet/magic-trace \nhttps://github.com/bloomberg/memray \nhttps://quii.gitbook.io/learn-go-with-tests/go-fundamentals/hello-world \nhttps://www.netlify.com/blog/announcing-serverless-compute-with-edge-functions \nhttps://workmode.co/ \nhttps://pixy.com/", "plat": 0, "device": "", "members": [], "jump_url": {"Python": {"title": "Python", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Python", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Python", "icon_position": 1}}, "max_line": 6, "bvid": "BV1fu41167ME"},{"message": "为方便小伙伴观看，可参见如下时间轴：\n00:08    一个有用网站的合集\n00:24    一个开源的 web 文本编辑器\n00:44    一个开源的分布式数据库\n01:11    OpenRefine｜开源数据清洗工具\n01:31    Node.js 发布18版本\n01:47    GO 发表介绍泛型的文章\n02:03    一个单手键盘\n本期 bgm｜siberian summer", "plat": 0, "device": "", "members": [], "jump_url": {"08": {"title": "08", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=08", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=08", "icon_position": 1}}, "max_line": 6, "bvid": "BV16B4y127vi"},{"message": "为方便小伙伴观看，可参见如下时间轴：\n00:09 现代 CLI 大全\n00:35 bore｜基于 Rust 的隧道工具\n00:53 WeekToDo｜本地计划管理工具\n01:09 Zas｜专注于 GO 和 Rust 的编辑器\n01:24 Pinry｜Pinterest 的开源替代品\n01:45 ｜Deno 推出 FaaS 服务\n02:13 EIGHT COLORS ｜一个小游戏", "plat": 0, "device": "", "members": [], "jump_url": {"Deno": {"title": "Deno", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Deno", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Deno", "icon_position": 1}}, "max_line": 6, "bvid": "BV1yi4y1U7Ms"},{"message": "为方便小伙伴观看，请参见如下时间轴：\n00:11 Coolify ｜自部署 PaaS\n00:29 warp｜现代化终端\n00:48 redo｜开源命令行工具\n00:59 MetricFlow｜数据仓库管理工具\n01:15 Ruby 增加 WASM 支持\n01:41 Rome 发布 Rome Formatter｜对标 Prettier\n02:04 一篇博客｜TypeScript 编译器工作原理\n02:18 一篇博客｜ 一些易被忽略的 HTML 属性", "plat": 0, "device": "", "members": [], "jump_url": {"Prettier": {"title": "Prettier", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Prettier", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Prettier", "icon_position": 1}}, "max_line": 6, "bvid": "BV12i4y1D78x"},{"message": "为方便小伙伴观看，请参见如下时间轴：[呲牙]\n00:09 GitHub issues 打印机\n00:29 Oh heck｜一个智能终端指令输入工具\n00:52 dagger｜一个现代化的 CI/CD 工具包\n01:11  React 发布18.0版本\n01:22 Chrome Experiments 的银河系实验\n01:40 arpchat｜用 ARP 协议实现的在线聊天工具\n02:03 Calenday｜ 一个多人共享日历\n02:21 WebAssembly 运行 Python\n02:49 Blog Search｜技术类搜索引擎", "plat": 0, "device": "", "members": [], "emote": {"[呲牙]": {"id": 1902, "package_id": 1, "state": 0, "type": 1, "attr": 0, "text": "[呲牙]", "url": "http://i0.hdslb.com/bfs/emote/b5a5898491944a4268360f2e7a84623149672eb6.png", "meta": {"size": 1}, "mtime": 1648834168, "jump_title": "呲牙"}}, "jump_url": {"dagger": {"title": "dagger", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=dagger", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=dagger", "icon_position": 1}}, "max_line": 6, "bvid": "BV1aF41137oA"},{"message": "为方便小伙伴们观看，整理了一个时间轴：\n00:08 appwrite｜为 web、mobile 和 flutter 开发者提供的开源后端服务\n00:37 Bionic Reading｜一个用高亮标注的阅读工具\n01:04 diagrams.net ｜老牌绘图工具更新功能\n01:19  Smort｜一个可编辑其它网站文章的工具\n01:49 fzf｜命令行中通用的模糊查询工具\n01:57 一个 node.js 的 Postgres 数据库客户端\n02:07 mdn 推出 plus 订阅计划｜Mozilla 商业化新尝试\n02:45 一篇题为 《Data Mesh 架构》的文章", "plat": 0, "device": "", "members": [], "jump_url": {"diagrams": {"title": "diagrams", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=diagrams", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=diagrams", "icon_position": 1}}, "max_line": 6, "bvid": "BV19S4y127wz"},{"message": "为方便大家观看，整理了时间轴如下：\n00:08 文献管理工具 Zotero 发布 6.0 版本\n00:25 Plasticity | 用 web 开发的3D 艺术建模开源软件\n00:55 Lapce ｜基于原生 GUI 和 Rust 编写的开源代码编辑器\n01:17 Awesome TUIs｜ 收集提供终端用户界面项目清单\n01:36  K9s ｜一个终端中 UI 强大的 K8s 客户端\n01:43 Tiny renderer｜500 行代码学习 openGL｜附演示教程\n02:00 GO 发布1.18版本支持泛型\n02:14 CSS-Tricks 网站被 DigitalOcean 收购\n02:35 Veloren ｜一个基于 Rust 开发的开源多人 RPG 游戏", "plat": 0, "device": "", "members": [], "jump_url": {"Lapce": {"title": "Lapce", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Lapce", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Lapce", "icon_position": 1}}, "max_line": 6, "bvid": "BV1HU4y1d7da"},{"message": "为方便大家观看，整理了时间轴：\n00:08 关于 TypeScript 的两条新闻\n00:21 TypeScript 向 JS 提议增加类型系统\n00:40 Stripe 将 JS 代码库从 Flow 迁移到 TypeScript \n01:17 Godot ｜一个开源游戏引擎\n01:41 苹果将发售 Mac Studio｜M1 芯片成为新杀手锏\n01:58 关于数据库索引工作原理的解答\n02:24 dasel ｜单一工具完成 JSON、TOML 等文件的读取和修改\n02:45  “请停止使用 :latest 标签”｜一篇关于版本安全的文章", "plat": 0, "device": "", "members": [], "jump_url": {"Godot": {"title": "Godot", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Godot", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Godot", "icon_position": 1}}, "max_line": 6, "bvid": "BV1VS4y1D768"},{"message": "为方便大家观看，整理了时间轴：\n00:08 Mozilla 的 MDN 文档全新上线\n00:41 Mozilla 的3D虚拟空间产品\n01:01 HOPPSCOTCH ｜一个开源网络请求发送工具\n01:19 Streamlit ｜一个使用 Python 直接开发 web UI 的工具\n01:42 Textframe ｜一个动画产品教程创建工具\n01:59 SaaS 产品开源替代品大全\n02:30 迷你掌上游戏机 playdate 开源了 SDK\n02:52 轻松一刻时间｜小游戏", "plat": 0, "device": "", "members": [], "jump_url": {"MDN": {"title": "MDN", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=MDN", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=MDN", "icon_position": 1}}, "max_line": 6, "bvid": "BV1Y34y1b7cJ"},{"message": "为方面大家观看，我整理了时间轴如下：\n00:09 怎样实现一个最简单的 CRUD 应用？｜本期专题问答\n00:32 Django｜CRUD 最佳工具/答案1\n00:49 PostgREST｜CRUD 最佳工具/答案2\n01:19 nHOST｜CRUD 最佳工具/答案3\n01:45 Grist｜Airtable 的开源替代\n02:06 Automerge｜JS 协同算法库\n02:34 Supernotes｜笔记软件\n02:45 Sioyek｜论文专用 PDF 阅读器", "plat": 0, "device": "", "members": [], "jump_url": {"CRUD": {"title": "CRUD", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=CRUD", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=CRUD", "icon_position": 1}}, "max_line": 6, "bvid": "BV1m34y1r7EY"},{"message": "[汤圆]", "plat": 0, "device": "", "members": [], "emote": {"[汤圆]": {"id": 5936, "package_id": 1, "state": 0, "type": 1, "attr": 0, "text": "[汤圆]", "url": "http://i0.hdslb.com/bfs/emote/93609633a9d194cf336687eb19c01dca95bde719.png", "meta": {"size": 1}, "mtime": 1644900361, "jump_title": "汤圆"}}, "jump_url": {}, "max_line": 6, "bvid": "BV19P4y1F7s7"},{"message": "为方便大家观看，整理了一个时间轴：[呲牙]\n00:09 Files Gallery｜应用\n00:22 Tally｜工具\n00:40 Datawrapper｜工具\n01:04 onemodel｜工具\n01:20 Postman｜工具\n01:29 Laravel 9.0 发布\n01:46 Mailwind｜邮件模版\n02:05《 backend.sql + frontend.js = love》｜文章\n02:25 《Top web hacking techniques of 2021》｜文章\n02:41 SHA256 算法可视化演示", "plat": 0, "device": "", "members": [], "emote": {"[呲牙]": {"id": 1902, "package_id": 1, "state": 0, "type": 1, "attr": 0, "text": "[呲牙]", "url": "http://i0.hdslb.com/bfs/emote/b5a5898491944a4268360f2e7a84623149672eb6.png", "meta": {"size": 1}, "mtime": 1648834168, "jump_title": "呲牙"}}, "jump_url": {"算法可视化": {"title": "算法可视化", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=算法可视化", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=算法可视化", "icon_position": 1}}, "max_line": 6, "bvid": "BV16a411y7fw"},{"aid": 851363567},{"aid": 808652802},{"message": "整理了本期周报的时间轴，方便大家观看：\n00:08 faker.js 删库事件新进展\n00:37 暴雪被收购\n01:00 PyFlow｜一个可视化编程环境\n01:14 CSS 选择器练习题网站\n01:27 GPS 工作原理详解\n01:47 Lichess | 一个国际象棋服务器的支出分析\n02:25 谷歌分析在欧盟合法性及其替代品\n02:53 AWS DynamoDB 十年回顾\n03:18 CyberChef | 一个数据格式转换工具\n03:32 curl | 最近支持了 JSON\n03:42 轻松一刻｜弹珠撞击木块游戏", "plat": 0, "device": "", "members": [], "jump_url": {"Lichess": {"title": "Lichess", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Lichess", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Lichess", "icon_position": 1}}, "max_line": 6, "bvid": "BV1AT4y127tr"},{"message": "整理了本期周报的时间轴，方便大家观看：\n00:07 开源软件被植入恶意代码\n00:38 Browsix 浏览器中实现 POSIX\n01:09 GitHub Copilot \n01:29 Learn and Test DMARC 一个可视化工具\n01:46 BookStack 一个开源 wiki 工具\n02:06 Poly Haven 如何花不到400美金处理80TB数据和500万次页面访问的\n03:33 Kogi 一个新型高级付费搜索引擎\n04:07 介绍两个 Cli 工具: dsq 和 fx\n04:38 轻松一刻时间｜介绍一个打发时间的小游戏", "plat": 0, "device": "", "members": [], "jump_url": {"Copilot": {"title": "Copilot", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=Copilot", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=Copilot", "icon_position": 1}}, "max_line": 6, "bvid": "BV1eT4y117Xh"},{"message": "整理了本期周报的时间轴，方便大家观看：\n00:09 任天堂掌上游戏机发展史回顾\n01:10 《为什么要运行自己的 DNS 服务器？》\n01:31 Zotero，一个开源的经典文献管理工具\n01:57 Darling，一个帮助你在 Linux 上运行 Mac 应用程序的工具\n02:16 coqui，克隆你的声音说外语\n02:35 OpenDrop, 一个开源版的 AirDrop\n02:53 Portmaster，一个帮助你管理电脑网络的开源软件\n03:20 Papers We Love，一个专门研读学术类计算机科学论文的开源社区\n03:42 关于 Zig 这个新兴编程语言的分析\n04:14 Raycast 团队信奉无需 code review 的理念\n04:50 利用浏览器 web GL 实现的东京地铁实时可视化地图\n05:13 SpaceX Dragon 2 与国际空间站对接的模拟机", "plat": 0, "device": "", "members": [], "jump_url": {"可视化地图": {"title": "可视化地图", "state": 0, "prefix_icon": "https://i0.hdslb.com/bfs/reply/9f3ad0659e84c96a711b88dd33f4bc2e945045e0.png", "app_url_schema": "bilibili://search?from=appcommentline_search&search_from_source=appcommentline_search&direct_return=true&keyword=可视化地图", "app_name": "", "app_package_name": "", "click_report": "", "is_half_screen": false, "exposure_report": "", "extra": {"goods_show_type": 0, "is_word_search": true, "goods_cm_control": 0, "goods_click_report": "", "goods_exposure_report": ""}, "underline": false, "match_once": true, "pc_url": "//search.bilibili.com/all?from_source=webcommentline_search&keyword=可视化地图", "icon_position": 1}}, "max_line": 6, "bvid": "BV1vL4y1b78S"},{"aid": 722854302},{"aid": 465206549}]
+[
+  {
+    "aid": 261620356,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 10
+        },
+        {
+          "minutes": 0,
+          "seconds": 28
+        },
+        {
+          "minutes": 0,
+          "seconds": 47
+        },
+        {
+          "minutes": 1,
+          "seconds": 10
+        },
+        {
+          "minutes": 1,
+          "seconds": 37
+        },
+        {
+          "minutes": 1,
+          "seconds": 54
+        },
+        {
+          "minutes": 2,
+          "seconds": 18
+        }
+      ],
+      "introduces": [
+        "Obsidian 发布 1.0",
+        "NocoDB｜ Airtable 开源替代品",
+        "通过代码编辑视频",
+        "Satori｜ 从 HTML 生成 SVG",
+        "aerc｜在命令行中编辑视频与收发邮件",
+        "Fleet｜Jet Brains 新一代 IDE",
+        "Go 语言设计讨论"
+      ],
+      "links": [
+        "https://obsidian.md/1.0",
+        "https://github.com/nocodb/nocodb",
+        "https://github.com/mifi",
+        "https://github.com/vercel/satori",
+        "https://aerc-mail.org/",
+        "https://www.jetbrains.com/fleet/",
+        "https://github.com/golang/go/discussions/56010"
+      ]
+    }
+  },
+  {
+    "aid": 346450481,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 31
+        },
+        {
+          "minutes": 0,
+          "seconds": 54
+        },
+        {
+          "minutes": 1,
+          "seconds": 16
+        },
+        {
+          "minutes": 1,
+          "seconds": 50
+        },
+        {
+          "minutes": 2,
+          "seconds": 6
+        },
+        {
+          "minutes": 2,
+          "seconds": 38
+        }
+      ],
+      "introduces": [
+        "sharing｜将电脑中的文件通过二维码分享给手机",
+        "Steampipe｜ 浏览云服务资产的交互式命令行工具",
+        "Horizon UI｜ 基于 Chakra UI 的管理后台模版",
+        "Postgres WASM｜ 开源 WASM 运行 PostgresSQL 方案",
+        "v86｜ 通过 WebAssembly 运行 x86 兼容的虚拟机",
+        "libSQL｜ SQLite 下游版本",
+        "TypeScript  10 years anniversary"
+      ],
+      "links": [
+        "https://github.com/parvardegr/sharing",
+        "https://steampipe.io/",
+        "https://horizon-ui.com/",
+        "https://supabase.com/blog/postgres-wasm",
+        "https://github.com/copy/v86",
+        [
+          "https://github.com/libsql/libsql",
+          "https://itnext.io/sqlite-qemu-all-over-again-aedad19c9a1c"
+        ],
+        "https://devblogs.microsoft.com/typescript/ten-years-of-typescript/"
+      ]
+    }
+  },
+  {
+    "aid": 388741659,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 35
+        },
+        {
+          "minutes": 0,
+          "seconds": 58
+        },
+        {
+          "minutes": 1,
+          "seconds": 33
+        },
+        {
+          "minutes": 2,
+          "seconds": 2
+        },
+        {
+          "minutes": 2,
+          "seconds": 16
+        },
+        {
+          "minutes": 2,
+          "seconds": 31
+        }
+      ],
+      "introduces": [
+        "SigNoz｜开源的 APM 系统",
+        "Wails｜使用 Go 和 Web 技术开发桌面端应用",
+        "CloudFlare 开源 serverless 运行时 workerd",
+        "Qwik｜builder.io 开源的前端框架",
+        "pdfgrep｜命令行搜索工具",
+        "Liqe｜轻量级搜索引擎",
+        "Google 计划关停云游戏服务 Stadia"
+      ],
+      "links": [
+        "https://github.com/SigNoz/signoz",
+        "https://wails.io/",
+        "https://github.com/cloudflare/workerd",
+        "https://qwik.builder.io/",
+        "https://pdfgrep.org/",
+        "https://github.com/gajus/liqe",
+        "https://www.theverge.com/2022/9/29/23378713/google-stadia-shutting-down-game-streaming-january-2023"
+      ]
+    }
+  },
+  {
+    "aid": 558499331,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 35
+        },
+        {
+          "minutes": 0,
+          "seconds": 58
+        },
+        {
+          "minutes": 1,
+          "seconds": 17
+        },
+        {
+          "minutes": 1,
+          "seconds": 33
+        },
+        {
+          "minutes": 1,
+          "seconds": 55
+        },
+        {
+          "minutes": 2,
+          "seconds": 15
+        },
+        {
+          "minutes": 2,
+          "seconds": 51
+        }
+      ],
+      "introduces": [
+        "GitUI｜Git 终端 UI",
+        "Dub｜开源短链接服务",
+        "WunderBase｜ serverless GraphQL 数据库",
+        "Rocketry｜现代化的 Python 调度框架",
+        "KREA｜AI 作画图库",
+        "Whisper｜ OpenAI 开源的语音识别系统",
+        "fly.io 开源新项目 LiteFS",
+        "Azure CTO Mark Russinovich 发推引发热议"
+      ],
+      "links": [
+        "https://github.com/extrawurst/gitui",
+        "https://dub.sh/",
+        "https://github.com/wundergraph/wunderbase",
+        "https://github.com/Miksus/rocketry",
+        "https://www.krea.ai/",
+        "https://openai.com/blog/whisper",
+        "https://fly.io/blog/introducing-litefs",
+        "https://twitter.com/markrussinovich/status/1571995117233504257"
+      ]
+    }
+  },
+  {
+    "aid": 303210611,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 31
+        },
+        {
+          "minutes": 0,
+          "seconds": 46
+        },
+        {
+          "minutes": 1,
+          "seconds": 8
+        },
+        {
+          "minutes": 1,
+          "seconds": 25
+        },
+        {
+          "minutes": 1,
+          "seconds": 37
+        },
+        {
+          "minutes": 1,
+          "seconds": 59
+        },
+        {
+          "minutes": 2,
+          "seconds": 14
+        }
+      ],
+      "introduces": [
+        "Figma 被收购引发在线设计工具新动向",
+        "penpot｜开源设计工具因 Figma 变热",
+        "Theatre.js｜开源在线动效编辑器",
+        "Markdoc｜交互式 Markdown",
+        "Meta 将 PyTorch 捐赠给 Linux 基金会",
+        "Meta 发布了网页内存泄漏检测工具 MemLab",
+        "SafeQL｜ 校验 SQL 的 ESLint 插件",
+        "Diffusion Bee｜在 M1 Mac 上运行 Stable Diffusion 的桌面端应用"
+      ],
+      "links": [
+        "https://www.bloomberg.com/news/articles/2022-09-15/adobe-is-said-to-near-deal-to-buy-online-design-startup-figma",
+        "https://penpot.app/",
+        "https://www.theatrejs.com/",
+        "https://markdoc.dev/",
+        "https://www.linuxfoundation.org/blog/blog/welcoming-pytorch-to-the-linux-foundation",
+        "https://engineering.fb.com/2022/09/12/open-source/memlab/",
+        "https://safeql.dev/",
+        "https://github.com/divamgupta/diffusionbee-stable-diffusion-ui"
+      ]
+    }
+  },
+  {
+    "aid": 560499744,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 11
+        },
+        {
+          "minutes": 0,
+          "seconds": 46
+        },
+        {
+          "minutes": 1,
+          "seconds": 12
+        },
+        {
+          "minutes": 1,
+          "seconds": 36
+        },
+        {
+          "minutes": 2,
+          "seconds": 3
+        },
+        {
+          "minutes": 2,
+          "seconds": 24
+        },
+        {
+          "minutes": 2,
+          "seconds": 37
+        }
+      ],
+      "introduces": [
+        "Difftastic｜结构化 diff 工具",
+        "ruff｜百倍快的 Python linter",
+        "DataEase｜数据可视化分析工具",
+        "MATHLIVE｜展示和编辑数学公式的 Web Component",
+        "VSCheatsheet｜VS Code 快捷键合集",
+        "Modern for Hacker News｜ 美化 Hacker News 界面的浏览器插件",
+        "signals｜PREACT 状态管理新方案"
+      ],
+      "links": [
+        "https://www.wilfred.me.uk/blog/2022/09/06/difftastic-the-fantastic-diff/",
+        "https://github.com/charliermarsh/ruff",
+        "https://github.com/dataease/dataease",
+        "https://cortexjs.io/mathlive",
+        "https://www.vscheatsheet.com/",
+        "https://www.modernhn.com/",
+        "https://preactjs.com/blog/introducing-signals/"
+      ]
+    }
+  },
+  {
+    "aid": 260156898,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 38
+        },
+        {
+          "minutes": 0,
+          "seconds": 52
+        },
+        {
+          "minutes": 1,
+          "seconds": 20
+        },
+        {
+          "minutes": 1,
+          "seconds": 42
+        },
+        {
+          "minutes": 2,
+          "seconds": 2
+        },
+        {
+          "minutes": 2,
+          "seconds": 37
+        },
+        {
+          "minutes": 3,
+          "seconds": 1
+        }
+      ],
+      "introduces": [
+        "Devbox｜快速启动隔离开发环境",
+        "绘图语言 D2",
+        "YAO｜开发应用引擎",
+        "JSON Crack｜JSON 可视化工具",
+        "Motionity｜动效编辑器",
+        "mvSQLite｜分布式 SQLite",
+        "Heroku 即将停止免费额度",
+        "GitHub 开发者关系副总裁回复移除 Trending"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 217441979,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 38
+        },
+        {
+          "minutes": 0,
+          "seconds": 59
+        },
+        {
+          "minutes": 1,
+          "seconds": 24
+        },
+        {
+          "minutes": 1,
+          "seconds": 43
+        },
+        {
+          "minutes": 2,
+          "seconds": 4
+        },
+        {
+          "minutes": 2,
+          "seconds": 26
+        }
+      ],
+      "introduces": [
+        "｜野心勃勃的数据库 SurrealDB",
+        "Stable Diffusion｜开源的 AI 图片生成模型",
+        "react-design-editor｜ Canva 的开源替代品",
+        "Weylus｜将触屏设备变为触摸板",
+        "eInk-VNC｜将 VMC 输出到墨水屏",
+        "SQLite 并发读取性能详解",
+        "80 岁计算机科学家仍在优化开源代码"
+      ],
+      "links": [
+        "https://surrealdb.com/",
+        "https://github.com/CompVis/stable-diffusion",
+        "https://github.com/layerhub-io/react-design-editor",
+        "https://github.com/H-M-H/Weylus",
+        "https://zmarshall.nl/static/eink-vnc.html",
+        "https://fly.io/blog/sqlite-internals-wal",
+        "https://news.ycombinator.com/item?id=32534173"
+      ]
+    }
+  },
+  {
+    "aid": 514731265,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 10
+        },
+        {
+          "minutes": 0,
+          "seconds": 34
+        },
+        {
+          "minutes": 0,
+          "seconds": 57
+        },
+        {
+          "minutes": 1,
+          "seconds": 22
+        },
+        {
+          "minutes": 1,
+          "seconds": 33
+        },
+        {
+          "minutes": 1,
+          "seconds": 53
+        }
+      ],
+      "introduces": [
+        "Numpad ｜一个新式文本编辑器",
+        "Erg｜与 Python 兼容的静态类型语言",
+        "分布式文件系统 JuiceFS",
+        "JiraCLI｜ 对 Jira 的命令行客户端",
+        "Crunchy Data｜在浏览器中运行 Postgres",
+        "JSON5 作者的一篇博客"
+      ],
+      "links": [
+        "https://numpad.io/",
+        "https://github.com/erg-lang/erg",
+        "https://github.com/juicedata/juicefs",
+        "https://github.com/ankitpokhrel/jira-cli",
+        "https://www.crunchydata.com/blog/learn-postgres-at-the-playground",
+        "https://aseemk.substack.com/p/ignore-the-f-ing-haters-json5"
+      ]
+    }
+  },
+  {
+    "aid": 601882126,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 34
+        },
+        {
+          "minutes": 1,
+          "seconds": 4
+        },
+        {
+          "minutes": 1,
+          "seconds": 28
+        },
+        {
+          "minutes": 1,
+          "seconds": 54
+        },
+        {
+          "minutes": 2,
+          "seconds": 21
+        }
+      ],
+      "introduces": [
+        "远程开发方案 Coder",
+        "高性能 virtual DOM",
+        "Astro 发布了 1.0 版本",
+        "Multy｜ 基于 Terraform 的跨云部署框架",
+        "Rancher 创始团队运营新开源产品 Acorn",
+        "一篇介绍 Redis 技术细节的文章"
+      ],
+      "links": [
+        "https://coder.com/",
+        "https://millionjs.org/",
+        "https://astro.build/blog/astro-1/",
+        "https://github.com/multycloud/multy",
+        "https://acorn.io/",
+        "https://architecturenotes.co/redis/"
+      ]
+    }
+  },
+  {
+    "aid": 899145721,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 8
+        },
+        {
+          "minutes": 0,
+          "seconds": 35
+        },
+        {
+          "minutes": 0,
+          "seconds": 52
+        },
+        {
+          "minutes": 1,
+          "seconds": 8
+        },
+        {
+          "minutes": 1,
+          "seconds": 24
+        },
+        {
+          "minutes": 1,
+          "seconds": 50
+        }
+      ],
+      "introduces": [
+        "开源知识库软件能否替代 Notion",
+        "Copilot 开源替代品",
+        "逆向工程工具箱",
+        "Emery｜效率工具",
+        "一篇介绍 eBPF 技术的文章",
+        "用 DALL·E 2 生成 logo 图片的分享文章"
+      ],
+      "links": [
+        "https://github.com/toeverything/AFFiNE",
+        "https://github.com/moyix/fauxpilot",
+        "https://github.com/WerWolv/ImHex",
+        "https://emery.to/",
+        "https://www.groundcover.com/blog/what-is-ebpf",
+        "https://jacobmartins.com/posts/how-i-used-dalle2-to-generate-the-logo-for-octosql/"
+      ]
+    }
+  },
+  {
+    "aid": 471440344,
+    "hn_items": {
+      "times": [],
+      "introduces": [],
+      "links": []
+    }
+  },
+  {
+    "aid": 856201719,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 11
+        },
+        {
+          "minutes": 0,
+          "seconds": 58
+        },
+        {
+          "minutes": 1,
+          "seconds": 40
+        },
+        {
+          "minutes": 2,
+          "seconds": 36
+        },
+        {
+          "minutes": 2,
+          "seconds": 58
+        },
+        {
+          "minutes": 3,
+          "seconds": 21
+        }
+      ],
+      "introduces": [
+        "Google 发布新编程语言 Carbon",
+        "榫卯｜ Sunmao ｜低代码工具开发框架",
+        "Comcast｜模拟弱网环境的工具",
+        "Tweakpane｜ 一个调节参数的 JS 库",
+        "AI 系统 DALL·E 开放 Beta 测试",
+        "一篇关于 Scratch 潜能的文章"
+      ],
+      "links": [
+        "https://github.com/carbon-language/carbon-lang",
+        "https://github.com/smartxworks/sunmao-ui",
+        "https://github.com/tylertreat/comcast",
+        "https://cocopon.github.io/tweakpane/",
+        "https://openai.com/blog/dall-e-now-available-in-beta",
+        "https://www.bryanbraun.com/2022/07/16/scratch-is-a-big-deal"
+      ]
+    }
+  },
+  {
+    "aid": 898526676,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 12
+        },
+        {
+          "minutes": 0,
+          "seconds": 30
+        },
+        {
+          "minutes": 1,
+          "seconds": 2
+        },
+        {
+          "minutes": 1,
+          "seconds": 49
+        },
+        {
+          "minutes": 2,
+          "seconds": 14
+        },
+        {
+          "minutes": 2,
+          "seconds": 36
+        }
+      ],
+      "introduces": [
+        "Vite 发布3.0版本",
+        "VictoriaMetrics｜Prometheus 的开源替代品",
+        "对 Bun 和 Node.js 对比实测",
+        "Cleanupphotos｜修图工具",
+        "Vim 在线交互式学习平台",
+        "推荐《PostgreSQL 14 Internals》一书"
+      ],
+      "links": [
+        "https://vitejs.dev/blog/announcing-vite3.html",
+        "https://victoriametrics.com/products/open-source/",
+        "https://techsparx.com/nodejs/bun/1st-trial.html",
+        "https://cleanupphotos.com/",
+        "https://www.vimified.com/",
+        "https://postgrespro.com/community/books/internals"
+      ]
+    }
+  },
+  {
+    "aid": 513340184,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 40
+        },
+        {
+          "minutes": 1,
+          "seconds": 2
+        },
+        {
+          "minutes": 1,
+          "seconds": 19
+        },
+        {
+          "minutes": 1,
+          "seconds": 44
+        },
+        {
+          "minutes": 2,
+          "seconds": 5
+        }
+      ],
+      "introduces": [
+        "Bun｜高性能 JS 运行时",
+        "TAURI｜Electron 轻量级替代品",
+        "Felt｜在线地图编辑网站",
+        "PocketBase｜ 开源实时后端方案",
+        "fuite｜自动探测 Web 应用内存泄漏",
+        "一篇关于 rsync 工作原理的文章"
+      ],
+      "links": [
+        "https://bun.sh/",
+        "https://tauri.app/",
+        "https://felt.com/",
+        "https://pocketbase.io/",
+        "https://github.com/nolanlawson/fuite",
+        "https://michael.stapelberg.ch/posts/2022-07-02-rsync-how-does-it-work"
+      ]
+    }
+  },
+  {
+    "aid": 770511400,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 10
+        },
+        {
+          "minutes": 0,
+          "seconds": 35
+        },
+        {
+          "minutes": 0,
+          "seconds": 55
+        },
+        {
+          "minutes": 1,
+          "seconds": 21
+        },
+        {
+          "minutes": 1,
+          "seconds": 49
+        },
+        {
+          "minutes": 2,
+          "seconds": 15
+        }
+      ],
+      "introduces": [
+        "Pyroscope｜性能持续分析工具",
+        "daisyUI｜前端组件库",
+        "《数据库必须知道的那些事》",
+        "《浏览器是如何工作的》",
+        "Spark 与 K8s 集成新动向",
+        "Raindrop｜书签管理小工具"
+      ],
+      "links": [
+        "https://pyroscope.io/",
+        "https://daisyui.com/",
+        "https://architecturenotes.co/things-you-should-know-about-databases",
+        "https://web.dev/howbrowserswork/",
+        "https://www.cncf.io/blog/2022/06/30/why-spark-chooses-volcano-as-built-in-batch-scheduler-on-kubernetes/",
+        "https://raindrop.io/"
+      ]
+    }
+  },
+  {
+    "aid": 427756499,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 1,
+          "seconds": 1
+        },
+        {
+          "minutes": 1,
+          "seconds": 21
+        },
+        {
+          "minutes": 1,
+          "seconds": 49
+        },
+        {
+          "minutes": 2,
+          "seconds": 23
+        },
+        {
+          "minutes": 2,
+          "seconds": 43
+        },
+        {
+          "minutes": 3,
+          "seconds": 4
+        }
+      ],
+      "introduces": [
+        "Viddy｜现代的 watch 替代品",
+        "Elastic UI｜Elastic 开源的前端 UI 组件库",
+        "Avo｜构建在 Ruby on Rails 方案之上的应用开发框架",
+        "Unclutter｜整理网页的浏览器插件",
+        "SQLite 发布 SQLite4 设计",
+        "Deno 完成 A 轮融资"
+      ],
+      "links": [
+        "https://github.blog/2022-06-21-github-copilot-is-generally-available-to-all-developers/",
+        "https://markwhen.com/",
+        "https://github.com/sachaos/viddy",
+        "https://elastic.github.io/eui/#/",
+        "https://avohq.io/",
+        "https://unclutter.lindylearn.io/",
+        "https://sqlite.org/src4/doc/trunk/www/design.wiki",
+        "https://deno.com/blog/series-a"
+      ]
+    }
+  },
+  {
+    "aid": 257594368,
+    "hn_items": {
+      "times": [],
+      "introduces": [],
+      "links": []
+    }
+  },
+  {
+    "aid": 727379202,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 30
+        },
+        {
+          "minutes": 0,
+          "seconds": 49
+        },
+        {
+          "minutes": 1,
+          "seconds": 6
+        },
+        {
+          "minutes": 1,
+          "seconds": 24
+        },
+        {
+          "minutes": 1,
+          "seconds": 42
+        }
+      ],
+      "introduces": [
+        "Knight Lab｜用代码更好地讲故事",
+        "plasmo｜浏览器插件开发平台",
+        "Shotcut｜开源免费跨平台视频编辑器",
+        "DEEPKIT｜Typescript 高性能框架",
+        "opensourcealternative.to｜查找开源替代品的网站",
+        "untools｜一组帮助思考的工具和方法论"
+      ],
+      "links": [
+        "https://knightlab.northwestern.edu/projects/",
+        "https://www.plasmo.com/",
+        "https://shotcut.org/",
+        "https://deepkit.io/",
+        "https://www.opensourcealternative.to/",
+        "https://untools.co/"
+      ]
+    }
+  },
+  {
+    "aid": 812156413,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 50
+        },
+        {
+          "minutes": 1,
+          "seconds": 12
+        },
+        {
+          "minutes": 1,
+          "seconds": 39
+        },
+        {
+          "minutes": 2,
+          "seconds": 18
+        },
+        {
+          "minutes": 2,
+          "seconds": 49
+        },
+        {
+          "minutes": 3,
+          "seconds": 5
+        },
+        {
+          "minutes": 3,
+          "seconds": 22
+        }
+      ],
+      "introduces": [
+        "Dragonfly｜一个25倍快的 Redis 竞品",
+        "PlantUML｜快速编写 UML 图",
+        "Neon｜开源 serverless Postgres 方案",
+        "ROAPI｜数据聚合 API",
+        "Tetra｜一个全栈框架",
+        "fd｜终端工具 Find 的替代品",
+        "svelvet｜交互式关系图构建工具",
+        "ffmpeg buddy｜FFmpeg 命令生成工具"
+      ],
+      "links": [
+        "https://github.com/dragonflydb/dragonfly",
+        "https://plantuml.com/",
+        "https://neon.tech/",
+        "https://github.com/roapi/roapi",
+        "https://www.tetraframework.com/",
+        "https://github.com/sharkdp/fd",
+        "https://svelvet.io/docs/basic-usage/",
+        "https://evanhahn.github.io/ffmpeg-buddy/"
+      ]
+    }
+  },
+  {
+    "aid": 639600552,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 26
+        },
+        {
+          "minutes": 0,
+          "seconds": 43
+        },
+        {
+          "minutes": 1,
+          "seconds": 3
+        },
+        {
+          "minutes": 1,
+          "seconds": 20
+        },
+        {
+          "minutes": 1,
+          "seconds": 32
+        },
+        {
+          "minutes": 1,
+          "seconds": 47
+        }
+      ],
+      "introduces": [
+        "PikaScript ｜ 超轻量级 Python 引擎",
+        "bionic-reading 的快速阅读英文插件",
+        "IndigoStack｜MacOS 平台上的本地开发环境",
+        "TypeScript 发布4.7版本",
+        "AnimatiSS｜一组 CSS 动画合集",
+        "Arctype｜ SQL 数据库客户端",
+        "一个有趣的3D 植物生成工具"
+      ],
+      "links": [
+        "https://github.com/pikasTech/pikascript",
+        "https://github.com/ansh/bionic-reading",
+        "https://indigostack.app/",
+        "https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/",
+        "https://xsgames.co/animatiss",
+        "https://arctype.com/",
+        "https://plant.jim-fx.com/"
+      ]
+    }
+  },
+  {
+    "aid": 214334199,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 38
+        },
+        {
+          "minutes": 0,
+          "seconds": 57
+        },
+        {
+          "minutes": 1,
+          "seconds": 17
+        },
+        {
+          "minutes": 1,
+          "seconds": 39
+        },
+        {
+          "minutes": 1,
+          "seconds": 56
+        },
+        {
+          "minutes": 2,
+          "seconds": 16
+        }
+      ],
+      "introduces": [
+        "Bud ｜ GO 的全栈 web 框架",
+        "Aspect ｜ 可视化开发 React 组件",
+        "在 SQLite 中使用 JSON 和 virtual columns",
+        "Sliderland｜一个极简风格的 JS 实验园地",
+        "LiveTerm｜开发终端风格网站",
+        "Datadog 介绍第三代事件存储库 Husky",
+        "Quastor｜一个汇集大厂架构分析的专栏频道"
+      ],
+      "links": [
+        "https://github.com/livebud/bud",
+        "https://aspect.app/",
+        "https://antonz.org/json-virtual-columns",
+        "https://sliderland.blinry.org/",
+        "https://liveterm.vercel.app/",
+        "https://www.datadoghq.com/blog/engineering/introducing-husky",
+        "https://quastor.substack.com/"
+      ]
+    }
+  },
+  {
+    "aid": 939044423,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 10
+        },
+        {
+          "minutes": 0,
+          "seconds": 40
+        },
+        {
+          "minutes": 0,
+          "seconds": 49
+        },
+        {
+          "minutes": 1,
+          "seconds": 21
+        },
+        {
+          "minutes": 1,
+          "seconds": 33
+        },
+        {
+          "minutes": 1,
+          "seconds": 54
+        },
+        {
+          "minutes": 2,
+          "seconds": 16
+        },
+        {
+          "minutes": 2,
+          "seconds": 30
+        }
+      ],
+      "introduces": [
+        "BoltDB 作者的博客｜如何在 fly.io 中使用 SQLite",
+        "Litestream｜ Sqlite 实时复制工具",
+        "Cloudflare 发布 D1",
+        "rqlite｜ 与 D1 相似的开源分布式数据库",
+        "CaskDB｜一个 kv 存储引擎的教学工具",
+        "CubeDesk｜魔方提速工具",
+        "DFlex ｜一个适配所有 JS 框架的可拖拽的工具库",
+        "一篇 JS 性能分析指南的文章"
+      ],
+      "links": [
+        "https://fly.io/blog/all-in-on-sqlite-litestream",
+        "https://github.com/benbjohnson/litestream",
+        "https://blog.cloudflare.com/introducing-d1/",
+        "https://github.com/rqlite/rqlite",
+        "https://github.com/avinassh/py-caskdb",
+        "https://www.cubedesk.io/home",
+        "https://www.dflex.dev/",
+        "https://blog.atomrc.dev/p/js-performance-profiling/"
+      ]
+    }
+  },
+  {
+    "aid": 596334116,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 37
+        },
+        {
+          "minutes": 0,
+          "seconds": 52
+        },
+        {
+          "minutes": 1,
+          "seconds": 10
+        },
+        {
+          "minutes": 1,
+          "seconds": 23
+        },
+        {
+          "minutes": 1,
+          "seconds": 39
+        },
+        {
+          "minutes": 2,
+          "seconds": 0
+        },
+        {
+          "minutes": 2,
+          "seconds": 21
+        }
+      ],
+      "introduces": [
+        "Anaconda 发布 PyScript｜浏览器中运行 Python",
+        "JSONHERO｜JSON 可视化工具",
+        "Spacedrive｜本地和云端同在的文件管理器",
+        "Bash-Oneliner｜一个事例仓库",
+        "Fig｜ 与 Warp 类似的终端",
+        "nosleep｜避免电脑休眠的网页",
+        "一篇关于 Golang 的文章",
+        "移植到 web 上的《塞尔达传说》"
+      ],
+      "links": [
+        "https://www.anaconda.com/blog/pyscript-python-in-the-browser",
+        "https://jsonhero.io/j/JZw4Wx9Mgj6r/tree",
+        "https://www.spacedrive.app/",
+        "https://github.com/onceupon/Bash-Oneliner",
+        "https://fig.io/",
+        "https://nosleep.page/",
+        "https://fasterthanli.me/articles/lies-we-tell-ourselves-to-keep-using-golang",
+        "https://hoten.cc/blog/porting-zelda-classic-to-the-web"
+      ]
+    }
+  },
+  {
+    "aid": 511210837,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 25
+        },
+        {
+          "minutes": 0,
+          "seconds": 49
+        },
+        {
+          "minutes": 1,
+          "seconds": 12
+        },
+        {
+          "minutes": 1,
+          "seconds": 31
+        },
+        {
+          "minutes": 1,
+          "seconds": 56
+        },
+        {
+          "minutes": 2,
+          "seconds": 25
+        }
+      ],
+      "introduces": [
+        "Clinic.js｜ Node.js 性能分析工具",
+        "magic-trace｜Jane Street 开源的进程监控工具",
+        "memray｜Bloomberg 开源的 Python 性能分析工具",
+        "《learn GO with Tests》｜练习 GO 的工具书",
+        "Edge Function｜Netlify 新推出的 PaaS 平台",
+        "workmode｜远程工作助手",
+        "pixy｜飞行相机"
+      ],
+      "links": [
+        "https://clinicjs.org/",
+        "https://github.com/janestreet/magic-trace",
+        "https://github.com/bloomberg/memray",
+        "https://quii.gitbook.io/learn-go-with-tests/go-fundamentals/hello-world",
+        "https://www.netlify.com/blog/announcing-serverless-compute-with-edge-functions",
+        "https://workmode.co/",
+        "https://pixy.com/"
+      ]
+    }
+  },
+  {
+    "aid": 595895504,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 8
+        },
+        {
+          "minutes": 0,
+          "seconds": 24
+        },
+        {
+          "minutes": 0,
+          "seconds": 44
+        },
+        {
+          "minutes": 1,
+          "seconds": 11
+        },
+        {
+          "minutes": 1,
+          "seconds": 31
+        },
+        {
+          "minutes": 1,
+          "seconds": 47
+        },
+        {
+          "minutes": 2,
+          "seconds": 3
+        }
+      ],
+      "introduces": [
+        "一个有用网站的合集",
+        "一个开源的 web 文本编辑器",
+        "一个开源的分布式数据库",
+        "OpenRefine｜开源数据清洗工具",
+        "Node.js 发布18版本",
+        "GO 发表介绍泛型的文章",
+        "一个单手键盘"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 553253895,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 35
+        },
+        {
+          "minutes": 0,
+          "seconds": 53
+        },
+        {
+          "minutes": 1,
+          "seconds": 9
+        },
+        {
+          "minutes": 1,
+          "seconds": 24
+        },
+        {
+          "minutes": 1,
+          "seconds": 45
+        },
+        {
+          "minutes": 2,
+          "seconds": 13
+        }
+      ],
+      "introduces": [
+        "现代 CLI 大全",
+        "bore｜基于 Rust 的隧道工具",
+        "WeekToDo｜本地计划管理工具",
+        "Zas｜专注于 GO 和 Rust 的编辑器",
+        "Pinry｜Pinterest 的开源替代品",
+        "｜Deno 推出 FaaS 服务",
+        "EIGHT COLORS ｜一个小游戏"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 553093356,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 11
+        },
+        {
+          "minutes": 0,
+          "seconds": 29
+        },
+        {
+          "minutes": 0,
+          "seconds": 48
+        },
+        {
+          "minutes": 0,
+          "seconds": 59
+        },
+        {
+          "minutes": 1,
+          "seconds": 15
+        },
+        {
+          "minutes": 1,
+          "seconds": 41
+        },
+        {
+          "minutes": 2,
+          "seconds": 4
+        },
+        {
+          "minutes": 2,
+          "seconds": 18
+        }
+      ],
+      "introduces": [
+        "Coolify ｜自部署 PaaS",
+        "warp｜现代化终端",
+        "redo｜开源命令行工具",
+        "MetricFlow｜数据仓库管理工具",
+        "Ruby 增加 WASM 支持",
+        "Rome 发布 Rome Formatter｜对标 Prettier",
+        "一篇博客｜TypeScript 编译器工作原理",
+        "一篇博客｜ 一些易被忽略的 HTML 属性"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 297873494,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 29
+        },
+        {
+          "minutes": 0,
+          "seconds": 52
+        },
+        {
+          "minutes": 1,
+          "seconds": 11
+        },
+        {
+          "minutes": 1,
+          "seconds": 22
+        },
+        {
+          "minutes": 1,
+          "seconds": 40
+        },
+        {
+          "minutes": 2,
+          "seconds": 3
+        },
+        {
+          "minutes": 2,
+          "seconds": 21
+        },
+        {
+          "minutes": 2,
+          "seconds": 49
+        }
+      ],
+      "introduces": [
+        "GitHub issues 打印机",
+        "Oh heck｜一个智能终端指令输入工具",
+        "dagger｜一个现代化的 CI/CD 工具包",
+        "React 发布18.0版本",
+        "Chrome Experiments 的银河系实验",
+        "arpchat｜用 ARP 协议实现的在线聊天工具",
+        "Calenday｜ 一个多人共享日历",
+        "WebAssembly 运行 Python",
+        "Blog Search｜技术类搜索引擎"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 725137289,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 8
+        },
+        {
+          "minutes": 0,
+          "seconds": 37
+        },
+        {
+          "minutes": 1,
+          "seconds": 4
+        },
+        {
+          "minutes": 1,
+          "seconds": 19
+        },
+        {
+          "minutes": 1,
+          "seconds": 49
+        },
+        {
+          "minutes": 1,
+          "seconds": 57
+        },
+        {
+          "minutes": 2,
+          "seconds": 7
+        },
+        {
+          "minutes": 2,
+          "seconds": 45
+        }
+      ],
+      "introduces": [
+        "appwrite｜为 web、mobile 和 flutter 开发者提供的开源后端服务",
+        "Bionic Reading｜一个用高亮标注的阅读工具",
+        "diagrams.net ｜老牌绘图工具更新功能",
+        "Smort｜一个可编辑其它网站文章的工具",
+        "fzf｜命令行中通用的模糊查询工具",
+        "一个 node.js 的 Postgres 数据库客户端",
+        "mdn 推出 plus 订阅计划｜Mozilla 商业化新尝试",
+        "一篇题为 《Data Mesh 架构》的文章"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 682476244,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 8
+        },
+        {
+          "minutes": 0,
+          "seconds": 25
+        },
+        {
+          "minutes": 0,
+          "seconds": 55
+        },
+        {
+          "minutes": 1,
+          "seconds": 17
+        },
+        {
+          "minutes": 1,
+          "seconds": 36
+        },
+        {
+          "minutes": 1,
+          "seconds": 43
+        },
+        {
+          "minutes": 2,
+          "seconds": 0
+        },
+        {
+          "minutes": 2,
+          "seconds": 14
+        },
+        {
+          "minutes": 2,
+          "seconds": 35
+        }
+      ],
+      "introduces": [
+        "文献管理工具 Zotero 发布 6.0 版本",
+        "Plasticity ｜ 用 web 开发的3D 艺术建模开源软件",
+        "Lapce ｜基于原生 GUI 和 Rust 编写的开源代码编辑器",
+        "Awesome TUIs｜ 收集提供终端用户界面项目清单",
+        "K9s ｜一个终端中 UI 强大的 K8s 客户端",
+        "Tiny renderer｜500 行代码学习 openGL｜附演示教程",
+        "GO 发布1.18版本支持泛型",
+        "CSS-Tricks 网站被 DigitalOcean 收购",
+        "Veloren ｜一个基于 Rust 开发的开源多人 RPG 游戏"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 724739860,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 8
+        },
+        {
+          "minutes": 0,
+          "seconds": 21
+        },
+        {
+          "minutes": 0,
+          "seconds": 40
+        },
+        {
+          "minutes": 1,
+          "seconds": 17
+        },
+        {
+          "minutes": 1,
+          "seconds": 41
+        },
+        {
+          "minutes": 1,
+          "seconds": 58
+        },
+        {
+          "minutes": 2,
+          "seconds": 24
+        },
+        {
+          "minutes": 2,
+          "seconds": 45
+        }
+      ],
+      "introduces": [
+        "关于 TypeScript 的两条新闻",
+        "TypeScript 向 JS 提议增加类型系统",
+        "Stripe 将 JS 代码库从 Flow 迁移到 TypeScript",
+        "Godot ｜一个开源游戏引擎",
+        "苹果将发售 Mac Studio｜M1 芯片成为新杀手锏",
+        "关于数据库索引工作原理的解答",
+        "dasel ｜单一工具完成 JSON、TOML 等文件的读取和修改",
+        "“请停止使用 :latest 标签”｜一篇关于版本安全的文章"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 809507046,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 8
+        },
+        {
+          "minutes": 0,
+          "seconds": 41
+        },
+        {
+          "minutes": 1,
+          "seconds": 1
+        },
+        {
+          "minutes": 1,
+          "seconds": 19
+        },
+        {
+          "minutes": 1,
+          "seconds": 42
+        },
+        {
+          "minutes": 1,
+          "seconds": 59
+        },
+        {
+          "minutes": 2,
+          "seconds": 30
+        },
+        {
+          "minutes": 2,
+          "seconds": 52
+        }
+      ],
+      "introduces": [
+        "Mozilla 的 MDN 文档全新上线",
+        "Mozilla 的3D虚拟空间产品",
+        "HOPPSCOTCH ｜一个开源网络请求发送工具",
+        "Streamlit ｜一个使用 Python 直接开发 web UI 的工具",
+        "Textframe ｜一个动画产品教程创建工具",
+        "SaaS 产品开源替代品大全",
+        "迷你掌上游戏机 playdate 开源了 SDK",
+        "轻松一刻时间｜小游戏"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 809272615,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 32
+        },
+        {
+          "minutes": 0,
+          "seconds": 49
+        },
+        {
+          "minutes": 1,
+          "seconds": 19
+        },
+        {
+          "minutes": 1,
+          "seconds": 45
+        },
+        {
+          "minutes": 2,
+          "seconds": 6
+        },
+        {
+          "minutes": 2,
+          "seconds": 34
+        },
+        {
+          "minutes": 2,
+          "seconds": 45
+        }
+      ],
+      "introduces": [
+        "怎样实现一个最简单的 CRUD 应用？｜本期专题问答",
+        "Django｜CRUD 最佳工具/答案1",
+        "PostgREST｜CRUD 最佳工具/答案2",
+        "nHOST｜CRUD 最佳工具/答案3",
+        "Grist｜Airtable 的开源替代",
+        "Automerge｜JS 协同算法库",
+        "Supernotes｜笔记软件",
+        "Sioyek｜论文专用 PDF 阅读器"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 894239914,
+    "hn_items": {
+      "times": [],
+      "introduces": [],
+      "links": []
+    }
+  },
+  {
+    "aid": 211446987,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 0,
+          "seconds": 22
+        },
+        {
+          "minutes": 0,
+          "seconds": 40
+        },
+        {
+          "minutes": 1,
+          "seconds": 4
+        },
+        {
+          "minutes": 1,
+          "seconds": 20
+        },
+        {
+          "minutes": 1,
+          "seconds": 29
+        },
+        {
+          "minutes": 1,
+          "seconds": 46
+        },
+        {
+          "minutes": 2,
+          "seconds": 5
+        },
+        {
+          "minutes": 2,
+          "seconds": 25
+        },
+        {
+          "minutes": 2,
+          "seconds": 41
+        }
+      ],
+      "introduces": [
+        "Files Gallery｜应用",
+        "Tally｜工具",
+        "Datawrapper｜工具",
+        "onemodel｜工具",
+        "Postman｜工具",
+        "Laravel 9.0 发布",
+        "Mailwind｜邮件模版",
+        "《 backend.sql + frontend.js = love》｜文章",
+        "《Top web hacking techniques of 2021》｜文章",
+        "SHA256 算法可视化演示"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 851363567,
+    "hn_items": {
+      "times": [],
+      "introduces": [],
+      "links": []
+    }
+  },
+  {
+    "aid": 808652802,
+    "hn_items": {
+      "times": [],
+      "introduces": [],
+      "links": []
+    }
+  },
+  {
+    "aid": 935758161,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 8
+        },
+        {
+          "minutes": 0,
+          "seconds": 37
+        },
+        {
+          "minutes": 1,
+          "seconds": 0
+        },
+        {
+          "minutes": 1,
+          "seconds": 14
+        },
+        {
+          "minutes": 1,
+          "seconds": 27
+        },
+        {
+          "minutes": 1,
+          "seconds": 47
+        },
+        {
+          "minutes": 2,
+          "seconds": 25
+        },
+        {
+          "minutes": 2,
+          "seconds": 53
+        },
+        {
+          "minutes": 3,
+          "seconds": 18
+        },
+        {
+          "minutes": 3,
+          "seconds": 32
+        },
+        {
+          "minutes": 3,
+          "seconds": 42
+        }
+      ],
+      "introduces": [
+        "faker.js 删库事件新进展",
+        "暴雪被收购",
+        "PyFlow｜一个可视化编程环境",
+        "CSS 选择器练习题网站",
+        "GPS 工作原理详解",
+        "Lichess ｜ 一个国际象棋服务器的支出分析",
+        "谷歌分析在欧盟合法性及其替代品",
+        "AWS DynamoDB 十年回顾",
+        "CyberChef ｜ 一个数据格式转换工具",
+        "curl ｜ 最近支持了 JSON",
+        "轻松一刻｜弹珠撞击木块游戏"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 935663579,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 7
+        },
+        {
+          "minutes": 0,
+          "seconds": 38
+        },
+        {
+          "minutes": 1,
+          "seconds": 9
+        },
+        {
+          "minutes": 1,
+          "seconds": 29
+        },
+        {
+          "minutes": 1,
+          "seconds": 46
+        },
+        {
+          "minutes": 2,
+          "seconds": 6
+        },
+        {
+          "minutes": 3,
+          "seconds": 33
+        },
+        {
+          "minutes": 4,
+          "seconds": 7
+        },
+        {
+          "minutes": 4,
+          "seconds": 38
+        }
+      ],
+      "introduces": [
+        "开源软件被植入恶意代码",
+        "Browsix 浏览器中实现 POSIX",
+        "GitHub Copilot",
+        "Learn and Test DMARC 一个可视化工具",
+        "BookStack 一个开源 wiki 工具",
+        "Poly Haven 如何花不到400美金处理80TB数据和500万次页面访问的",
+        "Kogi 一个新型高级付费搜索引擎",
+        "介绍两个 Cli 工具: dsq 和 fx",
+        "轻松一刻时间｜介绍一个打发时间的小游戏"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 850617825,
+    "hn_items": {
+      "times": [
+        {
+          "minutes": 0,
+          "seconds": 9
+        },
+        {
+          "minutes": 1,
+          "seconds": 10
+        },
+        {
+          "minutes": 1,
+          "seconds": 31
+        },
+        {
+          "minutes": 1,
+          "seconds": 57
+        },
+        {
+          "minutes": 2,
+          "seconds": 16
+        },
+        {
+          "minutes": 2,
+          "seconds": 35
+        },
+        {
+          "minutes": 2,
+          "seconds": 53
+        },
+        {
+          "minutes": 3,
+          "seconds": 20
+        },
+        {
+          "minutes": 3,
+          "seconds": 42
+        },
+        {
+          "minutes": 4,
+          "seconds": 14
+        },
+        {
+          "minutes": 4,
+          "seconds": 50
+        },
+        {
+          "minutes": 5,
+          "seconds": 13
+        }
+      ],
+      "introduces": [
+        "任天堂掌上游戏机发展史回顾",
+        "《为什么要运行自己的 DNS 服务器？》",
+        "Zotero，一个开源的经典文献管理工具",
+        "Darling，一个帮助你在 Linux 上运行 Mac 应用程序的工具",
+        "coqui，克隆你的声音说外语",
+        "OpenDrop, 一个开源版的 AirDrop",
+        "Portmaster，一个帮助你管理电脑网络的开源软件",
+        "Papers We Love，一个专门研读学术类计算机科学论文的开源社区",
+        "关于 Zig 这个新兴编程语言的分析",
+        "Raycast 团队信奉无需 code review 的理念",
+        "利用浏览器 web GL 实现的东京地铁实时可视化地图",
+        "SpaceX Dragon 2 与国际空间站对接的模拟机"
+      ],
+      "links": []
+    }
+  },
+  {
+    "aid": 722854302,
+    "hn_items": {
+      "times": [],
+      "introduces": [],
+      "links": []
+    }
+  },
+  {
+    "aid": 465206549,
+    "hn_items": {
+      "times": [],
+      "introduces": [],
+      "links": []
+    }
+  }
+]

--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ def parse_top_commont() -> None:
                         links.append(content.strip())
                     else:
                         continue
-                
+
                 bvid = top_commont[i]['bvid']
                 write_md(times, introduces, links, bvid)
 
@@ -122,7 +122,7 @@ def write_md(times: list[str], introduces: list[str], links: list[str], bvid: st
     :param links: 解析出来的链接
     :param bvid: 该视频的bvid
     """
-    
+
     vedio_url = f'https://www.bilibili.com/video/{bvid}'
     with open('README.md', 'a+', encoding='utf-8') as f:
         f.write(f'## [视频链接]({vedio_url})\n\n')

--- a/main.py
+++ b/main.py
@@ -59,33 +59,26 @@ def get_aids() -> Iterator[int]:
             yield aid
 
 
-@dataclass(frozen=True)
-class CommentData:
-    aid: int  # 视频av号
-    top_comment: str | None  # 置顶评论内容，可能不存在
-
-
-def get_comment_data() -> Iterator[CommentData]:
+def get_top_comment(aid: int) -> str | None:
     """
-    对每页获取到的评论进行处理，获取置顶评论
+    获取视频的置顶评论，如果没有置顶评论则返回 None
     """
     base_url = 'http://api.bilibili.com/x/v2/reply/main'
 
-    for aid in get_aids():
-        params = {
-            'type': 1,
-            'oid': aid,
-        }
-        response = requests.get(
-            url=base_url, params=params, headers=HEADERS, timeout=10)
-        response.raise_for_status()
-        comment_data = response.json()
+    params = {
+        'type': 1,
+        'oid': aid,
+    }
+    response = requests.get(
+        url=base_url, params=params, headers=HEADERS, timeout=10)
+    response.raise_for_status()
+    comment_data = response.json()
 
-        top_comment_data = comment_data['data']['top']['upper']
-        if top_comment_data is None:
-            yield CommentData(aid, None)
-        else:
-            yield CommentData(aid, top_comment_data['content']['message'])
+    top_comment_data = comment_data['data']['top']['upper']
+    if top_comment_data is None:
+        return None
+    else:
+        return top_comment_data['content']['message']
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
这个 PR 重构了 `main.py` 的数据抓取、文档生成的逻辑，使用 `dataclasses` 数据类和 `itertools` 来提高可读性，避免了一些一眼看不出来内容的 dict 和不必要的列表索引，更 pythonic。我尽可能把重构拆成了一系列提交，希望能便于理解一些。如果维护者对哪里有疑问，可以开 review 问我。

一个设计上比较大的更改是，不再每次都抓取一遍每个视频的置顶评论，然后解析并保存到 `data.json`，而是把这个 json 文件作为缓存，如果视频合集里的视频已经在缓存当中了，就不重新抓取，直接用缓存里的数据。这样一个好处是减少了一些不必要的网络请求，不过更重要的是这样就可以手动改写 `data.json` 文件，来补上一些置顶评论里缺失的信息（或者是干脆有些视频就没有置顶评论）。因此，我把 `data.json` 用 2 格缩进格式化保存了，这样可以在 git diff 里直观地看到做了哪些更改。

另外，代码做到了类型提示全覆盖，并且能通过 mypy 的静态类型检查，所以我把类型检查加到了 CI 里面。